### PR TITLE
Add a typeassert in `normalization`

### DIFF
--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -255,7 +255,7 @@ summary(p::ScaledPlan) = string(p.scale, " * ", summary(p.p))
 *(p::Plan, I::UniformScaling) = ScaledPlan(p, I.λ)
 
 # Normalization for ifft, given unscaled bfft, is 1/prod(dimensions)
-normalization(T, sz, region) = one(T) / Int(prod([sz...][[region...]]))
+normalization(T, sz, region) = one(T) / Int(prod([sz...][[region...]]))::Int
 normalization(X, region) = normalization(real(eltype(X)), size(X), region)
 
 plan_ifft(x::AbstractArray, region; kws...) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,3 +79,11 @@ end
     @test AbstractFFTs.ifftshift([1 2 3; 4 5 6], (1,2)) == [5 6 4; 2 3 1]
     @test AbstractFFTs.ifftshift([1 2 3; 4 5 6], 1:2) == [5 6 4; 2 3 1]
 end
+
+@testset "normalization" begin
+    # normalization should be inferable even if region is only inferred as ::Any,
+    # need to wrap in another function to test this (note that p.region::Any for
+    # p::TestPlan)
+    f9(p::Plan{T}, sz) where {T} = AbstractFFTs.normalization(real(T), sz, p.region)
+    @test @inferred(f9(plan_fft(zeros(10), 1), 10)) == 1/10
+end


### PR DESCRIPTION
`Int(x)` does no longer wrap `convert(Int, x)::Int`, so the type
assertion has be added manually to ensure inferability. Fixes
JuliaMath/FFTW.jl#57.