### PR TITLE
Updates for Julia 1.0+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ deps/usr
 deps/src
 docs/build
 docs/site
+Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: julia
 os:
   - linux
 julia:
-  - 0.6
+  - 1.0
+  - 1.1
   - nightly
 notifications:
   email: false
@@ -12,5 +13,13 @@ notifications:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("AbstractFFTs"); Pkg.test("AbstractFFTs"; coverage=true)'
 after_success:
-  - julia -e 'VERSION >= v"0.7-" && (Pkg.add("Coverage"); cd(Pkg.dir("AbstractFFTs")); using Coverage; Coveralls.submit(Coveralls.process_folder()))'
-  - julia -e 'VERSION >= v"0.7-" && (Pkg.add("Documenter"); cd(Pkg.dir("AbstractFFTs")); include(joinpath("docs", "make.jl")))'
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
+jobs:
+  include:
+    - stage: "Documentation"
+      julia: 1.0
+      os: linux
+      script:
+        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        - julia --project=docs/ docs/make.jl
+      after_success: skip

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,14 @@
+name = "AbstractFFTs"
+uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[compat]
+julia = "^1.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.6 0.7.0-DEV.602 0.7.0-DEV.3449
-Compat 0.59.0
+julia 1.0

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "~0.21"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,8 +2,6 @@ using Documenter, AbstractFFTs
 
 makedocs(
     modules = [AbstractFFTs],
-    clean = false,
-    format = :html,
     sitename = "AbstractFFTs.jl",
     pages = Any[
         "Home" => "index.md",
@@ -13,9 +11,6 @@ makedocs(
 )
 
 deploydocs(
-    julia = "nightly",
     repo = "github.com/JuliaMath/AbstractFFTs.jl.git",
     target = "build",
-    deps = nothing,
-    make = nothing,
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,3 +1,8 @@
+```@meta
+DocTestSetup = :(using AbstractFFTs)
+CurrentModule = AbstractFFTs
+```
+
 # AbstractFFTs.jl
 
 This package provides a generic framework for defining

--- a/src/AbstractFFTs.jl
+++ b/src/AbstractFFTs.jl
@@ -1,27 +1,10 @@
-VERSION < v"0.7.0-beta2.199" && __precompile__()
-
 module AbstractFFTs
 
-using Compat
-
-# After this version, the bindings can overwrite deprecated bindings in Base safely, but
-# prior to it we want to extend/reexport the Base definitions
-if VERSION < v"0.7.0-DEV.602"
-    import Base: fft, ifft, bfft, fft!, ifft!, bfft!,
-                 plan_fft, plan_ifft, plan_bfft, plan_fft!, plan_ifft!, plan_bfft!,
-                 rfft, irfft, brfft, plan_rfft, plan_irfft, plan_brfft,
-                 fftshift, ifftshift
-    import Base.DFT: Plan, ScaledPlan, plan_inv, pinv_type, normalization,
-                     rfft_output_size, brfft_output_size, realfloat, complexfloat
-end
-# Reexport the Base bindings unchanged for versions before FFTW was removed, or export the
-# new definitions after overwritable deprecation bindings were introduced
 export fft, ifft, bfft, fft!, ifft!, bfft!,
        plan_fft, plan_ifft, plan_bfft, plan_fft!, plan_ifft!, plan_bfft!,
        rfft, irfft, brfft, plan_rfft, plan_irfft, plan_brfft,
        fftshift, ifftshift
 
-# Only define things if we aren't using the existing Base bindings
-VERSION >= v"0.7.0-DEV.602" && include("definitions.jl")
+include("definitions.jl")
 
 end # module

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -246,13 +246,7 @@ size(p::ScaledPlan) = size(p.p)
 show(io::IO, p::ScaledPlan) = print(io, p.scale, " * ", p.p)
 summary(p::ScaledPlan) = string(p.scale, " * ", summary(p.p))
 
-if VERSION >= v"0.7.0-DEV.3665"
-    *(p::ScaledPlan, x::AbstractArray) = LinearAlgebra.rmul!(p.p * x, p.scale)
-elseif VERSION >= v"0.7.0-DEV.3563"
-    *(p::ScaledPlan, x::AbstractArray) = LinearAlgebra.mul1!(p.p * x, p.scale)
-else
-    *(p::ScaledPlan, x::AbstractArray) = scale!(p.p * x, p.scale)
-end
+*(p::ScaledPlan, x::AbstractArray) = LinearAlgebra.rmul!(p.p * x, p.scale)
 
 *(α::Number, p::Plan) = ScaledPlan(p, α)
 *(p::Plan, α::Number) = ScaledPlan(p, α)
@@ -272,16 +266,8 @@ plan_ifft!(x::AbstractArray, region; kws...) =
 
 plan_inv(p::ScaledPlan) = ScaledPlan(plan_inv(p.p), inv(p.scale))
 
-if VERSION >= v"0.7.0-DEV.3665"
-    LinearAlgebra.mul!(y::AbstractArray, p::ScaledPlan, x::AbstractArray) =
-        LinearAlgebra.lmul!(p.scale, LinearAlgebra.mul!(y, p.p, x))
-elseif VERSION >= v"0.7.0-DEV.3563"
-    LinearAlgebra.mul!(y::AbstractArray, p::ScaledPlan, x::AbstractArray) =
-        LinearAlgebra.mul2!(p.scale, LinearAlgebra.mul!(y, p.p, x))
-else
-    LinearAlgebra.mul!(y::AbstractArray, p::ScaledPlan, x::AbstractArray) =
-        scale!(p.scale, LinearAlgebra.mul!(y, p.p, x))
-end
+LinearAlgebra.mul!(y::AbstractArray, p::ScaledPlan, x::AbstractArray) =
+    LinearAlgebra.lmul!(p.scale, LinearAlgebra.mul!(y, p.p, x))
 
 ##############################################################################
 # Real-input DFTs are annoying because the output has a different size

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,15 +2,8 @@
 
 using AbstractFFTs
 using AbstractFFTs: Plan
-using Compat
-using Compat.LinearAlgebra
-using Compat.Test
-
-if VERSION < v"0.7.0-DEV.3204"
-    const mul! = Base.A_mul_B!
-else
-    const mul! = LinearAlgebra.mul!
-end
+using LinearAlgebra
+using Test
 
 mutable struct TestPlan{T} <: Plan{T}
     region


### PR DESCRIPTION
This drops support for Julia versions prior to 1.0, allowing us to simplify version checking logic and drop the dependency on Compat.

This also updates the documentation setup.