### PR TITLE
Simplify expression

### DIFF
--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -411,7 +411,7 @@ struct Frequencies{T<:Number} <: AbstractVector{T}
 end
 
 unsafe_getindex(x::Frequencies, i::Int) =
-    (i-1+ifelse(i <= x.n_nonnegative, 0, -x.n))*x.multiplier
+    (i-1-ifelse(i <= x.n_nonnegative, 0, x.n))*x.multiplier
 @inline function Base.getindex(x::Frequencies, i::Int)
     @boundscheck Base.checkbounds(x, i)
     unsafe_getindex(x, i)


### PR DESCRIPTION
Expression in `unsafe_getindex` is simpler and more understandable. However `@code_native` produces the same code (on Linux, x64) so there is no resulting optimization.