### PR TITLE
Use tuples in fftshift, and add copy method

### DIFF
--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -346,8 +346,6 @@ plan_irfft
 
 ##############################################################################
 
-fftshift(x) = circshift(x, div.([size(x)...],2))
-
 """
     fftshift(x, [dim])
 
@@ -363,15 +361,10 @@ If `dim` is not given then the signal is shifted along each dimension.
 """
 fftshift
 
-function fftshift(x,dim)
-    s = zeros(Int,ndims(x))
-    for i in dim
-        s[i] = div(size(x,i),2)
-    end
+function fftshift(x, dim = 1:ndims(x))
+    s = ntuple(d -> d in dim ? div(size(x,d),2) : 0, ndims(x))
     circshift(x, s)
 end
-
-ifftshift(x) = circshift(x, div.([size(x)...],-2))
 
 """
     ifftshift(x, [dim])
@@ -388,11 +381,8 @@ If `dim` is not given then the signal is shifted along each dimension.
 """
 ifftshift
 
-function ifftshift(x,dim)
-    s = zeros(Int,ndims(x))
-    for i in dim
-        s[i] = -div(size(x,i),2)
-    end
+function ifftshift(x, dim = 1:ndims(x))
+    s = ntuple(d -> d in dim ? -div(size(x,d),2) : 0, ndims(x))
     circshift(x, s)
 end
 
@@ -422,6 +412,8 @@ function Base.iterate(x::Frequencies, i::Int=1)
 end
 Base.size(x::Frequencies) = (x.n,)
 Base.step(x::Frequencies) = x.multiplier
+
+Base.copy(x::Frequencies) = x
 
 """
     fftfreq(n, fs=1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,6 +82,9 @@ end
 end
 
 @testset "FFT Frequencies" begin
+    @test fftfreq(8) isa Frequencies
+    @test copy(fftfreq(8)) isa Frequencies
+
     # N even
     @test fftfreq(8) == [0.0, 0.125, 0.25, 0.375, -0.5, -0.375, -0.25, -0.125]
     @test rfftfreq(8) == [0.0, 0.125, 0.25, 0.375, 0.5]


### PR DESCRIPTION
This was supposed to fix #36. Although in the end `@code_warntype fftshift(rand(ComplexF64,64,64))` shows no problems on the latest Julia (although it does print a bit less with this PR) and isn't fixed on Julia 1.0! 

It also adds a method for `copy(fftfreq(8))`, this previously gave an Array, whereas now it behaves like `copy(1:8)`. I think `collect(1:8)` or `Array(1:8)` are the ways to make an Array.