### PR TITLE
Fast extrema computation for Frequencies

### DIFF
--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -421,6 +421,10 @@ Broadcast.broadcasted(::typeof(*), x::Number, f::Frequencies) = Broadcast.broadc
 Broadcast.broadcasted(::typeof(/), f::Frequencies, x::Number) = Frequencies(f.n_nonnegative, f.n, f.multiplier / x)
 Broadcast.broadcasted(::typeof(\), x::Number, f::Frequencies) = Broadcast.broadcasted(/, f, x)
 
+Base.maximum(f::Frequencies) = ifelse(f.multiplier >= 0, (f.n_nonnegative - 1) * f.multiplier, (f.n_nonnegative - f.n) * f.multiplier)
+Base.minimum(f::Frequencies) = ifelse(f.multiplier >= 0, (f.n_nonnegative - f.n) * f.multiplier, (f.n_nonnegative - 1) * f.multiplier)
+Base.extrema(f::Frequencies) = (minimum(f), maximum(f))
+
 """
     fftfreq(n, fs=1)
 Return the discrete Fourier transform (DFT) sample frequencies for a DFT of length `n`. The returned

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -421,8 +421,8 @@ Broadcast.broadcasted(::typeof(*), x::Number, f::Frequencies) = Broadcast.broadc
 Broadcast.broadcasted(::typeof(/), f::Frequencies, x::Number) = Frequencies(f.n_nonnegative, f.n, f.multiplier / x)
 Broadcast.broadcasted(::typeof(\), x::Number, f::Frequencies) = Broadcast.broadcasted(/, f, x)
 
-Base.maximum(f::Frequencies) = ifelse(f.multiplier >= 0, (f.n_nonnegative - 1) * f.multiplier, (f.n_nonnegative - f.n) * f.multiplier)
-Base.minimum(f::Frequencies) = ifelse(f.multiplier >= 0, (f.n_nonnegative - f.n) * f.multiplier, (f.n_nonnegative - 1) * f.multiplier)
+Base.maximum(f::Frequencies) = (f.n_nonnegative - ifelse(f.multiplier >= 0, 1, f.n)) * f.multiplier
+Base.minimum(f::Frequencies) = (f.n_nonnegative - ifelse(f.multiplier >= 0, f.n, 1)) * f.multiplier
 Base.extrema(f::Frequencies) = (minimum(f), maximum(f))
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,6 +114,18 @@ end
         @test 2 \ fftfreq(4, 1) === fftfreq(4, 1/2)
         @test 2 .\ fftfreq(4, 1) === fftfreq(4, 1/2)
     end
+
+    @testset "extrema" begin
+        function check_extrema(freqs)
+            for f in [minimum, maximum, extrema]
+                @test f(freqs) == f(collect(freqs)) == f(fftshift(freqs))
+            end
+        end
+        for f in (fftfreq, rfftfreq), n in (8, 9), multiplier in (2, 1/3, -1/7)
+            freqs = f(n, multiplier)
+            check_extrema(freqs)
+        end
+    end
 end
 
 @testset "normalization" begin


### PR DESCRIPTION
The minimum and maximum for a `Frequencies` object may be computed without iteration.

on master:
```julia
julia> freqs = fftfreq(100, 1);

julia> @btime maximum($freqs)
  451.650 ns (0 allocations: 0 bytes)
0.49
```

After this PR:

```julia
julia> @btime maximum($(Ref(freqs))[])
  3.194 ns (0 allocations: 0 bytes)
0.49
```

It effectively uses the bounds from `fftshift`. The reason to avoid calling `fftshift` directly is that constructing the range is expensive, but computing the bounds is cheap.