### PR TITLE
Improve inferrability

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AbstractFFTs"
 uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
-version = "0.5.0"
+version = "1.0.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,16 @@ using AbstractFFTs: Plan
 using LinearAlgebra
 using Test
 
+@testset "rfft sizes" begin
+    A = rand(11, 10)
+    @test @inferred(AbstractFFTs.rfft_output_size(A, 1)) == (6, 10)
+    @test @inferred(AbstractFFTs.rfft_output_size(A, 2)) == (11, 6)
+    A1 = rand(6, 10); A2 = rand(11, 6)
+    @test @inferred(AbstractFFTs.brfft_output_size(A1, 11, 1)) == (11, 10)
+    @test @inferred(AbstractFFTs.brfft_output_size(A2, 10, 2)) == (11, 10)
+    @test_throws AssertionError AbstractFFTs.brfft_output_size(A1, 10, 2)
+end
+
 mutable struct TestPlan{T} <: Plan{T}
     region
     pinv::Plan{T}


### PR DESCRIPTION
This is technically a breaking change because it returns the sizes as
tuples rather than vectors. Hence I've taken the liberty of bumping
the version number.