### PR TITLE
Error message for a partially implemented plan

### DIFF
--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -205,6 +205,7 @@ rfft(x::AbstractArray{<:Union{Integer,Rational}}, region=1:ndims(x)) = rfft(real
 plan_rfft(x::AbstractArray, region; kws...) = plan_rfft(realfloat(x), region; kws...)
 
 # only require implementation to provide *(::Plan{T}, ::Array{T})
+*(p::Plan{T}, x::Array{T}) where {T} = error("Overload Base.:*(::$(typeof(p)), ::Array{$T})")
 *(p::Plan{T}, x::AbstractArray) where {T} = p * copy1(T, x)
 
 # Implementations should also implement mul!(Y, plan, X) so as to support


### PR DESCRIPTION
This avoids the following stack overflow:
```julia
[1] circcopy!(::Array{Float64,2}, ::Array{Float64,2}) at ./multidimensional.jl:1071
 [2] copy1 at /Users/solver/.julia/packages/AbstractFFTs/JAxy0/src/definitions.jl:38 [inlined]
 [3] *(::SphericalHarmonics.SphericalHarmonicTransform{Float64}, ::Array{Float64,2}) at /Users/solver/.julia/packages/AbstractFFTs/JAxy0/src/definitions.jl:208 (repeats 51959 times)
```
Haven't had time to add a test but can do it once the implementation is agreed (that is, the error type/message).