### PR TITLE
Added type of frequency clarification

### DIFF
--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -429,6 +429,7 @@ Return the discrete Fourier transform (DFT) sample frequencies for a DFT of leng
 `Frequencies` object is an `AbstractVector` containing the frequency
 bin centers at every sample point. `fs` is the sampling rate of the
 input signal, which is the reciprocal of the sample spacing.
+The return values are not to be confused with angular frequency.
 
 Given a window of length `n` and a sampling rate `fs`, the frequencies returned are
 
@@ -464,6 +465,7 @@ Return the discrete Fourier transform (DFT) sample frequencies for a real DFT of
 The returned `Frequencies` object is an `AbstractVector`
 containing the frequency bin centers at every sample point. `fs`
 is the sampling rate of the input signal, which is the reciprocal of the sample spacing.
+The return values are not to be confused with angular frequency.
 
 Given a window of length `n` and a sampling rate `fs`, the frequencies returned are
 

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -429,7 +429,7 @@ Return the discrete Fourier transform (DFT) sample frequencies for a DFT of leng
 `Frequencies` object is an `AbstractVector` containing the frequency
 bin centers at every sample point. `fs` is the sampling rate of the
 input signal, which is the reciprocal of the sample spacing.
-The return values are not to be confused with angular frequency.
+The return values are not to be confused with angular frequency, which is obtained by multiplying the output with 2pi.
 
 Given a window of length `n` and a sampling rate `fs`, the frequencies returned are
 
@@ -465,7 +465,7 @@ Return the discrete Fourier transform (DFT) sample frequencies for a real DFT of
 The returned `Frequencies` object is an `AbstractVector`
 containing the frequency bin centers at every sample point. `fs`
 is the sampling rate of the input signal, which is the reciprocal of the sample spacing.
-The return values are not to be confused with angular frequency.
+The return values are not to be confused with angular frequency, which is obtained by multiplying the output with 2pi.
 
 Given a window of length `n` and a sampling rate `fs`, the frequencies returned are
 

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -429,7 +429,7 @@ Return the discrete Fourier transform (DFT) sample frequencies for a DFT of leng
 `Frequencies` object is an `AbstractVector` containing the frequency
 bin centers at every sample point. `fs` is the sampling rate of the
 input signal, which is the reciprocal of the sample spacing.
-The return values are not to be confused with angular frequency, which is obtained by multiplying the output with 2pi.
+The return values are not to be confused with angular frequency, which is obtained by multiplying the output with `2pi`.
 
 Given a window of length `n` and a sampling rate `fs`, the frequencies returned are
 
@@ -465,7 +465,7 @@ Return the discrete Fourier transform (DFT) sample frequencies for a real DFT of
 The returned `Frequencies` object is an `AbstractVector`
 containing the frequency bin centers at every sample point. `fs`
 is the sampling rate of the input signal, which is the reciprocal of the sample spacing.
-The return values are not to be confused with angular frequency, which is obtained by multiplying the output with 2pi.
+The return values are not to be confused with angular frequency, which is obtained by multiplying the output with `2pi`.
 
 Given a window of length `n` and a sampling rate `fs`, the frequencies returned are
 

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -429,7 +429,7 @@ Return the discrete Fourier transform (DFT) sample frequencies for a DFT of leng
 `Frequencies` object is an `AbstractVector` containing the frequency
 bin centers at every sample point. `fs` is the sampling rate of the
 input signal, which is the reciprocal of the sample spacing.
-The return values are not to be confused with angular frequency, which is obtained by multiplying the output with `2pi`.
+The return values are not to be confused with angular frequencies, which are obtained by multiplying the output by `2π`.
 
 Given a window of length `n` and a sampling rate `fs`, the frequencies returned are
 
@@ -465,7 +465,7 @@ Return the discrete Fourier transform (DFT) sample frequencies for a real DFT of
 The returned `Frequencies` object is an `AbstractVector`
 containing the frequency bin centers at every sample point. `fs`
 is the sampling rate of the input signal, which is the reciprocal of the sample spacing.
-The return values are not to be confused with angular frequency, which is obtained by multiplying the output with `2pi`.
+The return values are not to be confused with angular frequencies, which are obtained by multiplying the output by `2π`.
 
 Given a window of length `n` and a sampling rate `fs`, the frequencies returned are
 


### PR DESCRIPTION
In reading the documentation for `fftfreqs`, I did not find what I came there for - a clarification about if the frequencies were measured in oscillations/second, or radians/second. From my background (engineering student), I am used to talking about angular frequencies in most cases, and so the fact that normal frequency is returned was not obvious to me, an indication that it might not be to everyone. I have therefore appended the following line in the docs for `fftfreq` and `rfftfreq`:
`The return values are not to be confused with angular frequency.`

I considered specifying the unit of oscillation/second, but I felt like specifying this without adding "as opposed to..." was weird, and when adding it, it is longer and more trailing than this solution. Other suggestions are very welcome