### PR TITLE
Make minimum/maximum generic for Frequencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ julia = "^1.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Unitful"]

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -419,8 +419,8 @@ Broadcast.broadcasted(::typeof(*), x::Number, f::Frequencies) = Broadcast.broadc
 Broadcast.broadcasted(::typeof(/), f::Frequencies, x::Number) = Frequencies(f.n_nonnegative, f.n, f.multiplier / x)
 Broadcast.broadcasted(::typeof(\), x::Number, f::Frequencies) = Broadcast.broadcasted(/, f, x)
 
-Base.maximum(f::Frequencies) = (f.n_nonnegative - ifelse(f.multiplier >= 0, 1, f.n)) * f.multiplier
-Base.minimum(f::Frequencies) = (f.n_nonnegative - ifelse(f.multiplier >= 0, f.n, 1)) * f.multiplier
+Base.maximum(f::Frequencies{T}) where T = (f.n_nonnegative - ifelse(f.multiplier >= zero(T), 1, f.n)) * f.multiplier
+Base.minimum(f::Frequencies{T}) where T = (f.n_nonnegative - ifelse(f.multiplier >= zero(T), f.n, 1)) * f.multiplier
 Base.extrema(f::Frequencies) = (minimum(f), maximum(f))
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,8 @@ using AbstractFFTs: Plan
 using LinearAlgebra
 using Test
 
+import Unitful
+
 @testset "rfft sizes" begin
     A = rand(11, 10)
     @test @inferred(AbstractFFTs.rfft_output_size(A, 1)) == (6, 10)
@@ -131,7 +133,7 @@ end
                 @test f(freqs) == f(collect(freqs)) == f(fftshift(freqs))
             end
         end
-        for f in (fftfreq, rfftfreq), n in (8, 9), multiplier in (2, 1/3, -1/7)
+        for f in (fftfreq, rfftfreq), n in (8, 9), multiplier in (2, 1/3, -1/7, 1.0*Unitful.mm)
             freqs = f(n, multiplier)
             check_extrema(freqs)
         end


### PR DESCRIPTION
Before:
```
julia> import Unitful: mm
julia> using FFTW
julia> fftfreq(10, 1.0mm);
julia> minimum(f)
ERROR: DimensionError: 0.0 and 0.1 mm are not dimensionally compatible.
```
After:
```
julia> import Unitful: mm
julia> using FFTW
julia> fftfreq(10, 1.0mm);
julia> minimum(f)
-0.5mm
```

I didn't include a test, but if you are ok w/ including `Unitful` in test dependencies I can put that in.