### PR TITLE
Compact show for Frequencies

### DIFF
--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -465,8 +465,10 @@ Base.extrema(f::Frequencies) = (minimum(f), maximum(f))
 function Base.show(io::IO, f::Frequencies)
     r1 = 0:f.n_nonnegative-1
     r2 = -f.n + f.n_nonnegative:-1
-    v = "[$r1;" * (isempty(r2) ? "" : " $r2") * "]"
-    print(io, "$v*$(step(f))")
+    print(io, "[", r1, ";")
+    !isempty(r2) && print(io, " ", r2)
+    print(io, "]*", step(f))
+    return nothing
 end
 
 """

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -462,13 +462,8 @@ Base.maximum(f::Frequencies{T}) where T = (f.n_nonnegative - ifelse(f.multiplier
 Base.minimum(f::Frequencies{T}) where T = (f.n_nonnegative - ifelse(f.multiplier >= zero(T), f.n, 1)) * f.multiplier
 Base.extrema(f::Frequencies) = (minimum(f), maximum(f))
 
-function Base.show(io::IO, f::Frequencies)
-    r1 = 0:f.n_nonnegative-1
-    r2 = -f.n + f.n_nonnegative:-1
-    print(io, "[", r1, ";")
-    !isempty(r2) && print(io, " ", r2)
-    print(io, "]*", step(f))
-    return nothing
+function show(io::IO, f::Frequencies)
+    print(io, Frequencies, "(", f.n_nonnegative, ", ", f.n, ", ", f.multiplier, ")")
 end
 
 """

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -462,6 +462,13 @@ Base.maximum(f::Frequencies{T}) where T = (f.n_nonnegative - ifelse(f.multiplier
 Base.minimum(f::Frequencies{T}) where T = (f.n_nonnegative - ifelse(f.multiplier >= zero(T), f.n, 1)) * f.multiplier
 Base.extrema(f::Frequencies) = (minimum(f), maximum(f))
 
+function Base.show(io::IO, f::Frequencies)
+    r1 = 0:f.n_nonnegative-1
+    r2 = -f.n + f.n_nonnegative:-1
+    v = "[$r1;" * (isempty(r2) ? "" : " $r2") * "]"
+    print(io, "$v*$(step(f))")
+end
+
 """
     fftfreq(n, fs=1)
 Return the discrete Fourier transform (DFT) sample frequencies for a DFT of length `n`. The returned

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,19 +110,10 @@ end
     end
 
     @testset "show" begin
-        for f in Any[fftfreq(6), fftfreq(7, 2), rfftfreq(5, 0.3), rfftfreq(4, 3)]
-            fnn = f.n_nonnegative
-            r1 = 0:fnn - 1
-            r2 = -length(f) + fnn:-1
-            v = [r1; r2] * step(f)
-            @test v ≈ f
-            s = repr(f)
-            if !isempty(r2) # fftfreq
-                @test s == "[$r1; $r2]*$(step(f))"
-            else # rfftfreq
-                @test s == "[$r1;]*$(step(f))"
-            end
-        end
+        @test repr(fftfreq(6)) == "Frequencies(3, 6, $(1/6))"
+        @test repr(fftfreq(7, 2)) == "Frequencies(4, 7, $(2/7))"
+        @test repr(rfftfreq(5, 0.3)) == "Frequencies(3, 3, $(0.3/5))"
+        @test repr(rfftfreq(4, 3)) == "Frequencies(3, 3, $(3/4))"
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,6 +108,22 @@ end
             check_extrema(freqs)
         end
     end
+
+    @testset "show" begin
+        for f in Any[fftfreq(6), fftfreq(7, 2), rfftfreq(5, 0.3), rfftfreq(4, 3)]
+            fnn = f.n_nonnegative
+            r1 = 0:fnn - 1
+            r2 = -length(f) + fnn:-1
+            v = [r1; r2] * step(f)
+            @test v ≈ f
+            s = repr(f)
+            if !isempty(r2) # fftfreq
+                @test s == "[$r1; $r2]*$(step(f))"
+            else # rfftfreq
+                @test s == "[$r1;]*$(step(f))"
+            end
+        end
+    end
 end
 
 @testset "normalization" begin


### PR DESCRIPTION
This PR specializes `show` for `Frequencies`. It's a workaround for https://github.com/JuliaLang/julia/issues/39963, and in general this makes the output more readable while displaying frequencies obtained from `fftfreq` and `rfftfreq`.

On master
```julia
julia> f = fftfreq(5, 0.3)
5-element Frequencies{Float64}:
  0.0
  0.06
  0.12
 -0.12
 -0.06

julia> show(f)
[0.0, 0.06, 0.12, -0.12, -0.06]

julia> f = rfftfreq(5, 0.3)
3-element Frequencies{Float64}:
 0.0
 0.06
 0.12

julia> show(f)
[0.0, 0.06, 0.12]
```

After this PR:
```julia
julia> f = fftfreq(5, 0.3)
5-element Frequencies{Float64}:
  0.0
  0.06
  0.12
 -0.12
 -0.06

julia> show(f)
[0:2; -2:-1]*0.06

julia> f = rfftfreq(5, 0.3)
3-element Frequencies{Float64}:
 0.0
 0.06
 0.12

julia> show(f)
[0:2;]*0.06
```

As a consequence:

on master
```julia
julia> g() = rfftfreq(100, 1)
g (generic function with 1 method)

julia> @code_warntype g()
Variables
  #self#::Core.Const(g)

Body::Frequencies{Float64}
1 ─ %1 = Main.rfftfreq(100, 1)::Core.Const([0.0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.2, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.3, 0.31, 0.32, 0.33, 0.34, 0.35000000000000003, 0.36, 0.37, 0.38, 0.39, 0.4, 0.41000000000000003, 0.42, 0.43, 0.44, 0.45, 0.46, 0.47000000000000003, 0.48, 0.49, 0.5])
└──      return %1
```

After this PR:
```julia
julia> @code_warntype g()
Variables
  #self#::Core.Const(g)

Body::Frequencies{Float64}
1 ─ %1 = Main.rfftfreq(100, 1)::Core.Const([0:50;]*0.01)
└──      return %1
````