### PR TITLE
fix docs not deploying for tagged versions

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -12,3 +12,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
I noticed that the documentation for v1.0.0 (and following) wasn't deployed.
@pfitzseb found the problem: TagBot should be configured with the documenter key, as explained in the [Documenter.jl docs](https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#GitHub-Actions).
The next tagged version should then have the docs deployed correctly.

Edit: this fixes #60 