### PR TITLE
Chain rules for FFT plans via AdjointPlans

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,9 +12,10 @@ julia = "^1.0"
 
 [extras]
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
+FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["ChainRulesTestUtils", "Random", "Test", "Unitful"]
+test = ["ChainRulesTestUtils", "FiniteDifferences", "Random", "Test", "Unitful"]

--- a/README.md
+++ b/README.md
@@ -16,25 +16,4 @@ This allows multiple FFT packages to co-exist with the same underlying `fft(x)` 
 
 ## Developer information
 
-To define a new FFT implementation in your own module, you should
-
-* Define a new subtype (e.g. `MyPlan`) of `AbstractFFTs.Plan{T}` for FFTs and related transforms on arrays of `T`.
-  This must have a `pinv::Plan` field, initially undefined when a `MyPlan` is created, that is used for caching the
-  inverse plan.
-
-* Define a new method `AbstractFFTs.plan_fft(x, region; kws...)` that returns a `MyPlan` for at least some types of
-  `x` and some set of dimensions `region`.   The `region` (or a copy thereof) should be accessible via `fftdims(p::MyPlan)` (which defaults to `p.region`).
-
-* Define a method of `LinearAlgebra.mul!(y, p::MyPlan, x)` (or `A_mul_B!(y, p::MyPlan, x)` on Julia prior to
-  0.7.0-DEV.3204) that computes the transform `p` of `x` and stores the result in `y`.
-
-* Define a method of `*(p::MyPlan, x)`, which can simply call your `mul!` (or `A_mul_B!`) method.
-  This is not defined generically in this package due to subtleties that arise for in-place and real-input FFTs.
-
-* If the inverse transform is implemented, you should also define `plan_inv(p::MyPlan)`, which should construct the
-  inverse plan to `p`, and `plan_bfft(x, region; kws...)` for an unnormalized inverse ("backwards") transform of `x`.
-
-* You can also define similar methods of `plan_rfft` and `plan_brfft` for real-input FFTs.
-
-The normalization convention for your FFT should be that it computes yₖ = ∑ⱼ xⱼ exp(-2πi jk/n) for a transform of
-length n, and the "backwards" (unnormalized inverse) transform computes the same thing but with exp(+2πi jk/n).
+To define a new FFT implementation in your own module, see [defining a new implementation](https://juliamath.github.io/AbstractFFTs.jl/stable/implementations/#Defining-a-new-implementation).

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -20,6 +20,7 @@ AbstractFFTs.plan_rfft
 AbstractFFTs.plan_brfft
 AbstractFFTs.plan_irfft
 AbstractFFTs.fftdims
+Base.adjoint
 AbstractFFTs.fftshift
 AbstractFFTs.fftshift!
 AbstractFFTs.ifftshift

--- a/docs/src/implementations.md
+++ b/docs/src/implementations.md
@@ -32,10 +32,10 @@ To define a new FFT implementation in your own module, you should
 
 * You can also define similar methods of `plan_rfft` and `plan_brfft` for real-input FFTs.
 
-* To enable automatic computation of adjoint plans via [`Base.adjoint`](@ref) (used in rules for reverse-mode differentiation), define the trait `AbstractFFTs.ProjectionStyle(::MyPlan)`, which can take values:
+* To enable automatic computation of adjoint plans via [`Base.adjoint`](@ref) (used in rules for reverse-mode differentiation), define the trait `AbstractFFTs.ProjectionStyle(::MyPlan)`, which can return:
     * `AbstractFFTs.NoProjectionStyle()`,
-    * `AbstractFFTs.RealProjectionStyle()`, for plans which halve one of the output's dimensions analogously to [`rfft`](@ref),
-    * `AbstractFFTs.RealInverseProjectionStyle(d::Int)`, for plans which expect an input with a halved dimension analogously to [`irfft`](@ref), where `d` is the original length of the dimension.
+    * `AbstractFFTs.RealProjectionStyle()`, for plans that halve one of the output's dimensions analogously to [`rfft`](@ref),
+    * `AbstractFFTs.RealInverseProjectionStyle(d::Int)`, for plans that expect an input with a halved dimension analogously to [`irfft`](@ref), where `d` is the original length of the dimension.
 
-The normalization convention for your FFT should be that it computes yₖ = ∑ⱼ xⱼ exp(-2πi jk/n) for a transform of
-length n, and the "backwards" (unnormalized inverse) transform computes the same thing but with exp(+2πi jk/n).
+The normalization convention for your FFT should be that it computes ``y_k = \sum_j x_j \exp(-2\pi i j k/n)`` for a transform of
+length ``n``, and the "backwards" (unnormalized inverse) transform computes the same thing but with ``\exp(+2\pi i jk/n)``.

--- a/docs/src/implementations.md
+++ b/docs/src/implementations.md
@@ -20,10 +20,9 @@ To define a new FFT implementation in your own module, you should
 * Define a new method `AbstractFFTs.plan_fft(x, region; kws...)` that returns a `MyPlan` for at least some types of
   `x` and some set of dimensions `region`.   The `region` (or a copy thereof) should be accessible via `fftdims(p::MyPlan)` (which defaults to `p.region`).
 
-* Define a method of `LinearAlgebra.mul!(y, p::MyPlan, x)` (or `A_mul_B!(y, p::MyPlan, x)` on Julia prior to
-  0.7.0-DEV.3204) that computes the transform `p` of `x` and stores the result in `y`.
+* Define a method of `LinearAlgebra.mul!(y, p::MyPlan, x)` that computes the transform `p` of `x` and stores the result in `y`.
 
-* Define a method of `*(p::MyPlan, x)`, which can simply call your `mul!` (or `A_mul_B!`) method.
+* Define a method of `*(p::MyPlan, x)`, which can simply call your `mul!` method.
   This is not defined generically in this package due to subtleties that arise for in-place and real-input FFTs.
 
 * If the inverse transform is implemented, you should also define `plan_inv(p::MyPlan)`, which should construct the
@@ -33,7 +32,7 @@ To define a new FFT implementation in your own module, you should
 
 * You can also define similar methods of `plan_rfft` and `plan_brfft` for real-input FFTs.
 
-* To enable automatic computation of adjoint plans via [`Base.adjoint`](@ref) (used in rules for reverse differentiation), define the trait `AbstractFFTs.ProjectionStyle(::MyPlan)`, which can take values:
+* To enable automatic computation of adjoint plans via [`Base.adjoint`](@ref) (used in rules for reverse-mode differentiation), define the trait `AbstractFFTs.ProjectionStyle(::MyPlan)`, which can take values:
     * `AbstractFFTs.NoProjectionStyle()`,
     * `AbstractFFTs.RealProjectionStyle()`, for plans which halve one of the output's dimensions analogously to [`rfft`](@ref),
     * `AbstractFFTs.RealInverseProjectionStyle(d::Int)`, for plans which expect an input with a halved dimension analogously to [`irfft`](@ref), where `d` is the original length of the dimension.

--- a/docs/src/implementations.md
+++ b/docs/src/implementations.md
@@ -11,16 +11,32 @@ The following packages extend the functionality provided by AbstractFFTs:
 
 ## Defining a new implementation
 
-Implementations should implement `LinearAlgebra.mul!(Y, plan, X)` (or
-`A_mul_B!(y, p::MyPlan, x)` on Julia prior to 0.7.0-DEV.3204) so as to support
-pre-allocated output arrays.
-We don't define `*` in terms of `mul!` generically here, however, because
-of subtleties for in-place and real FFT plans.
+To define a new FFT implementation in your own module, you should
 
-To support `inv`, `\`, and `ldiv!(y, plan, x)`, we require `Plan` subtypes
-to have a `pinv::Plan` field, which caches the inverse plan, and which should be
-initially undefined.
-They should also implement `plan_inv(p)` to construct the inverse of a plan `p`.
+* Define a new subtype (e.g. `MyPlan`) of `AbstractFFTs.Plan{T}` for FFTs and related transforms on arrays of `T`.
+  This must have a `pinv::Plan` field, initially undefined when a `MyPlan` is created, that is used for caching the
+  inverse plan.
 
-Implementations only need to provide the unnormalized backwards FFT,
-similar to FFTW, and we do the scaling generically to get the inverse FFT.
+* Define a new method `AbstractFFTs.plan_fft(x, region; kws...)` that returns a `MyPlan` for at least some types of
+  `x` and some set of dimensions `region`.   The `region` (or a copy thereof) should be accessible via `fftdims(p::MyPlan)` (which defaults to `p.region`).
+
+* Define a method of `LinearAlgebra.mul!(y, p::MyPlan, x)` (or `A_mul_B!(y, p::MyPlan, x)` on Julia prior to
+  0.7.0-DEV.3204) that computes the transform `p` of `x` and stores the result in `y`.
+
+* Define a method of `*(p::MyPlan, x)`, which can simply call your `mul!` (or `A_mul_B!`) method.
+  This is not defined generically in this package due to subtleties that arise for in-place and real-input FFTs.
+
+* If the inverse transform is implemented, you should also define `plan_inv(p::MyPlan)`, which should construct the
+  inverse plan to `p`, and `plan_bfft(x, region; kws...)` for an unnormalized inverse ("backwards") transform of `x`.
+  Implementations only need to provide the unnormalized backwards FFT, similar to FFTW, and we do the scaling generically
+  to get the inverse FFT.
+
+* You can also define similar methods of `plan_rfft` and `plan_brfft` for real-input FFTs.
+
+* To enable automatic computation of adjoint plans via [`Base.adjoint`](@ref) (used in rules for reverse differentiation), define the trait `AbstractFFTs.ProjectionStyle(::MyPlan)`, which can take values:
+    * `AbstractFFTs.NoProjectionStyle()`,
+    * `AbstractFFTs.RealProjectionStyle()`, for plans which halve one of the output's dimensions analogously to [`rfft`](@ref),
+    * `AbstractFFTs.RealInverseProjectionStyle(d::Integer)`, for plans which expect an input with a halved dimension analogously to [`irfft`](@ref), where `d` is the original length of the dimension.
+
+The normalization convention for your FFT should be that it computes yₖ = ∑ⱼ xⱼ exp(-2πi jk/n) for a transform of
+length n, and the "backwards" (unnormalized inverse) transform computes the same thing but with exp(+2πi jk/n).

--- a/docs/src/implementations.md
+++ b/docs/src/implementations.md
@@ -36,7 +36,7 @@ To define a new FFT implementation in your own module, you should
 * To enable automatic computation of adjoint plans via [`Base.adjoint`](@ref) (used in rules for reverse differentiation), define the trait `AbstractFFTs.ProjectionStyle(::MyPlan)`, which can take values:
     * `AbstractFFTs.NoProjectionStyle()`,
     * `AbstractFFTs.RealProjectionStyle()`, for plans which halve one of the output's dimensions analogously to [`rfft`](@ref),
-    * `AbstractFFTs.RealInverseProjectionStyle(d::Integer)`, for plans which expect an input with a halved dimension analogously to [`irfft`](@ref), where `d` is the original length of the dimension.
+    * `AbstractFFTs.RealInverseProjectionStyle(d::Int)`, for plans which expect an input with a halved dimension analogously to [`irfft`](@ref), where `d` is the original length of the dimension.
 
 The normalization convention for your FFT should be that it computes yₖ = ∑ⱼ xⱼ exp(-2πi jk/n) for a transform of
 length n, and the "backwards" (unnormalized inverse) transform computes the same thing but with exp(+2πi jk/n).

--- a/ext/AbstractFFTsChainRulesCoreExt.jl
+++ b/ext/AbstractFFTsChainRulesCoreExt.jl
@@ -161,12 +161,18 @@ end
 
 # plans
 function ChainRulesCore.frule((_, _, Δx), ::typeof(*), P::AbstractFFTs.Plan, x::AbstractArray) 
-    y = P * x 
+    y = P * x
+    if Base.mightalias(y, x)
+        throw(ArgumentError("differentiation rules are not supported for in-place plans"))
+    end
     Δy = P * Δx
     return y, Δy
 end
 function ChainRulesCore.rrule(::typeof(*), P::AbstractFFTs.Plan, x::AbstractArray)
     y = P * x
+    if Base.mightalias(y, x)
+        throw(ArgumentError("differentiation rules are not supported for in-place plans"))
+    end
     project_x = ChainRulesCore.ProjectTo(x)
     Pt = P'
     function mul_plan_pullback(ȳ)
@@ -178,11 +184,17 @@ end
 
 function ChainRulesCore.frule((_, ΔP, Δx), ::typeof(*), P::AbstractFFTs.ScaledPlan, x::AbstractArray) 
     y = P * x 
+    if Base.mightalias(y, x)
+        throw(ArgumentError("differentiation rules are not supported for in-place plans"))
+    end
     Δy = P * Δx .+ (ΔP.scale / P.scale) .* y
     return y, Δy
 end
 function ChainRulesCore.rrule(::typeof(*), P::AbstractFFTs.ScaledPlan, x::AbstractArray)
     y = P * x
+    if Base.mightalias(y, x)
+        throw(ArgumentError("differentiation rules are not supported for in-place plans"))
+    end
     Pt = P'
     scale = P.scale
     project_x = ChainRulesCore.ProjectTo(x)

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -170,20 +170,19 @@ end
 
 function ChainRulesCore.frule((_, ΔP, Δx), ::typeof(*), P::ScaledPlan, x::AbstractArray) 
     y = P * x 
-    Δy = P * Δx + ΔP.scale / P.scale * y
+    Δy = P * Δx .+ (ΔP.scale / P.scale) .* y
     return y, Δy
 end
 function ChainRulesCore.rrule(::typeof(*), P::ScaledPlan, x::AbstractArray)
     y = P * x
     project_x = ChainRulesCore.ProjectTo(x)
-    project_scale = ChainRulesCore.ProjectTo(P.scale)
     Pt = P'
     scale = P.scale
-    function mul_plan_pullback(ȳ)
+    function mul_scaledplan_pullback(ȳ)
         x̄ = ChainRulesCore.@thunk(project_x(Pt * ȳ))
-        scale_tangent = ChainRulesCore.@thunk(project_scale(sum(conj(y) .* ȳ) / conj(scale)))
+        scale_tangent = ChainRulesCore.@thunk(dot(y, ȳ) / conj(scale))
         plan_tangent = ChainRulesCore.Tangent{typeof(P)}(;p=ChainRulesCore.NoTangent(), scale=scale_tangent)
         return ChainRulesCore.NoTangent(), plan_tangent, x̄ 
     end
-    return y, mul_plan_pullback
+    return y, mul_scaledplan_pullback
 end

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -175,12 +175,13 @@ function ChainRulesCore.frule((_, ΔP, Δx), ::typeof(*), P::ScaledPlan, x::Abst
 end
 function ChainRulesCore.rrule(::typeof(*), P::ScaledPlan, x::AbstractArray)
     y = P * x
-    project_x = ChainRulesCore.ProjectTo(x)
     Pt = P'
     scale = P.scale
+    project_x = ChainRulesCore.ProjectTo(x)
+    project_scale = ChainRulesCore.ProjectTo(scale)
     function mul_scaledplan_pullback(ȳ)
         x̄ = ChainRulesCore.@thunk(project_x(Pt * ȳ))
-        scale_tangent = ChainRulesCore.@thunk(dot(y, ȳ) / conj(scale))
+        scale_tangent = ChainRulesCore.@thunk(project_scale(dot(y, ȳ) / conj(scale)))
         plan_tangent = ChainRulesCore.Tangent{typeof(P)}(;p=ChainRulesCore.NoTangent(), scale=scale_tangent)
         return ChainRulesCore.NoTangent(), plan_tangent, x̄ 
     end

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -167,3 +167,23 @@ function ChainRulesCore.rrule(::typeof(*), P::Plan, x::AbstractArray)
     end
     return y, mul_plan_pullback
 end
+
+function ChainRulesCore.frule((_, ΔP, Δx), ::typeof(*), P::ScaledPlan, x::AbstractArray) 
+    y = P * x 
+    Δy = P * Δx + ΔP.scale / P.scale * y
+    return y, Δy
+end
+function ChainRulesCore.rrule(::typeof(*), P::ScaledPlan, x::AbstractArray)
+    y = P * x
+    project_x = ChainRulesCore.ProjectTo(x)
+    project_scale = ChainRulesCore.ProjectTo(P.scale)
+    Pt = P'
+    scale = P.scale
+    function mul_plan_pullback(ȳ)
+        x̄ = ChainRulesCore.@thunk(project_x(Pt * ȳ))
+        scale_tangent = ChainRulesCore.@thunk(project_scale(sum(conj(y) .* ȳ) / conj(scale)))
+        plan_tangent = ChainRulesCore.Tangent{typeof(P)}(;p=ChainRulesCore.NoTangent(), scale=scale_tangent)
+        return ChainRulesCore.NoTangent(), plan_tangent, x̄ 
+    end
+    return y, mul_plan_pullback
+end

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -150,3 +150,20 @@ function ChainRulesCore.rrule(::typeof(ifftshift), x::AbstractArray, dims)
     end
     return y, ifftshift_pullback
 end
+
+# plans
+function ChainRulesCore.frule((_, _, Δx), ::typeof(*), P::Plan, x::AbstractArray) 
+    y = P * x 
+    Δy = P * Δx
+    return y, Δy
+end
+function ChainRulesCore.rrule(::typeof(*), P::Plan, x::AbstractArray)
+    y = P * x
+    project_x = ChainRulesCore.ProjectTo(x)
+    Pt = P'
+    function mul_plan_pullback(ȳ)
+        x̄ = project_x(Pt * ȳ)
+        return ChainRulesCore.NoTangent(), ChainRulesCore.NoTangent(), x̄
+    end
+    return y, mul_plan_pullback
+end

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -583,7 +583,9 @@ plan_brfft
 
 struct NoProjectionStyle end
 struct RealProjectionStyle end 
-struct RealInverseProjectionStyle end
+struct RealInverseProjectionStyle 
+    dim::Int
+end
 const ProjectionStyle = Union{NoProjectionStyle, RealProjectionStyle, RealInverseProjectionStyle}
 
 function irfft_dim end
@@ -591,7 +593,7 @@ function irfft_dim end
 output_size(p::Plan) = _output_size(p, ProjectionStyle(p))
 _output_size(p::Plan, ::NoProjectionStyle) = size(p)
 _output_size(p::Plan, ::RealProjectionStyle) = rfft_output_size(size(p), region(p))
-_output_size(p::Plan, ::RealInverseProjectionStyle) = brfft_output_size(size(p), irfft_dim(p), region(p))
+_output_size(p::Plan, s::RealInverseProjectionStyle) = brfft_output_size(size(p), s.dim, region(p))
 
 mutable struct AdjointPlan{T,P<:Plan} <: Plan{T}
     p::P

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -644,3 +644,6 @@ function _mul(p::AdjointPlan{T}, x::AbstractArray, ::RealInverseProjectionStyle)
 end
 
 plan_inv(p::AdjointPlan) = adjoint(plan_inv(p.p))
+function LinearAlgebra.mul!(y::AbstractArray, p::AdjointPlan, x::AbstractArray)
+    throw(MethodError(LinearAlgebra.mul!, "mul! is not supported for adjoint plans"))
+end

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -588,8 +588,6 @@ struct RealInverseProjectionStyle
 end
 const ProjectionStyle = Union{NoProjectionStyle, RealProjectionStyle, RealInverseProjectionStyle}
 
-function irfft_dim end
-
 output_size(p::Plan) = _output_size(p, ProjectionStyle(p))
 _output_size(p::Plan, ::NoProjectionStyle) = size(p)
 _output_size(p::Plan, ::RealProjectionStyle) = rfft_output_size(size(p), fftdims(p))

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -638,7 +638,7 @@ function _mul(p::AdjointPlan{T}, x::AbstractArray, ::RealProjectionStyle) where 
         [(i == 1 || (i == n && 2 * (i - 1)) == d) ? N : 2 * N for i in 1:n],
         ntuple(i -> i == halfdim ? n : 1, Val(ndims(x)))
     )
-    return p.p \ (x ./ scale)
+    return p.p \ (x ./ convert(typeof(x), scale))
 end
 
 function _mul(p::AdjointPlan{T}, x::AbstractArray, ::RealInverseProjectionStyle) where {T}
@@ -651,7 +651,7 @@ function _mul(p::AdjointPlan{T}, x::AbstractArray, ::RealInverseProjectionStyle)
         [(i == 1 || (i == n && 2 * (i - 1)) == d) ? 1 : 2 for i in 1:n],
         ntuple(i -> i == halfdim ? n : 1, Val(ndims(x)))
     )
-    return scale ./ N .* (p.p \ x)
+    return (convert(typeof(x), scale) ./ N) .* (p.p \ x)
 end
 
 # Analogously to ScaledPlan, define both plan_inv (for no caching) and inv (caches inner plan only).

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -12,6 +12,7 @@ eltype(::Type{<:Plan{T}}) where {T} = T
 
 # size(p) should return the size of the input array for p
 size(p::Plan, d) = size(p)[d]
+output_size(p::Plan, d) = output_size(p)[d]
 ndims(p::Plan) = length(size(p))
 length(p::Plan) = prod(size(p))::Int
 
@@ -255,6 +256,7 @@ ScaledPlan(p::Plan{T}, scale::Number) where {T} = ScaledPlan{T}(p, scale)
 ScaledPlan(p::ScaledPlan, α::Number) = ScaledPlan(p.p, p.scale * α)
 
 size(p::ScaledPlan) = size(p.p)
+output_size(p::ScaledPlan) = output_size(p.p)
 
 fftdims(p::ScaledPlan) = fftdims(p.p)
 
@@ -576,3 +578,67 @@ Pre-plan an optimized real-input unnormalized transform, similar to
 the same as for [`brfft`](@ref).
 """
 plan_brfft
+
+##############################################################################
+
+struct NoProjectionStyle end
+struct RealProjectionStyle end 
+struct RealInverseProjectionStyle end
+const ProjectionStyle = Union{NoProjectionStyle, RealProjectionStyle, RealInverseProjectionStyle}
+
+function irfft_dim end
+
+output_size(p::Plan) = _output_size(p, ProjectionStyle(p))
+_output_size(p::Plan, ::NoProjectionStyle) = size(p)
+_output_size(p::Plan, ::RealProjectionStyle) = rfft_output_size(size(p), region(p))
+_output_size(p::Plan, ::RealInverseProjectionStyle) = brfft_output_size(size(p), irfft_dim(p), region(p))
+
+mutable struct AdjointPlan{T,P} <: Plan{T}
+    p::P
+    pinv::Plan
+    AdjointPlan{T,P}(p) where {T,P} = new(p)
+end
+
+Base.adjoint(p::Plan{T}) where {T} = AdjointPlan{T, typeof(p)}(p)
+Base.adjoint(p::AdjointPlan{T}) where {T} = p.p
+# always have AdjointPlan inside ScaledPlan.
+Base.adjoint(p::ScaledPlan{T}) where {T} = ScaledPlan{T}(p.p', p.scale)
+
+size(p::AdjointPlan) = output_size(p.p)
+output_size(p::AdjointPlan) = size(p.p)
+
+Base.:*(p::AdjointPlan, x::AbstractArray) = _mul(p, x, ProjectionStyle(p.p))
+
+function _mul(p::AdjointPlan{T}, x::AbstractArray, ::NoProjectionStyle) where {T}
+    dims = region(p.p)
+    N = normalization(T, size(p.p), dims)
+    return 1/N * (p.p \ x)
+end
+
+function _mul(p::AdjointPlan{T}, x::AbstractArray, ::RealProjectionStyle) where {T}
+    dims = region(p.p)
+    N = normalization(T, size(p.p), dims)
+    halfdim = first(dims)
+    d = size(p.p, halfdim)
+    n = output_size(p.p, halfdim)
+    scale = reshape(
+        [(i == 1 || (i == n && 2 * (i - 1)) == d) ? 1 : 2 for i in 1:n],
+        ntuple(i -> i == first(dims) ? n : 1, Val(ndims(x)))
+    )
+    return 1/N * (p.p \ (x ./ scale))
+end
+
+function _mul(p::AdjointPlan{T}, x::AbstractArray, ::RealInverseProjectionStyle) where {T}
+    dims = region(p.p)
+    N = normalization(real(T), output_size(p.p), dims)
+    halfdim = first(dims)
+    n = size(p.p, halfdim)
+    d = output_size(p.p, halfdim)
+    scale = reshape(
+        [(i == 1 || (i == n && 2 * (i - 1)) == d) ? 1 : 2 for i in 1:n],
+        ntuple(i -> i == first(dims) ? n : 1, Val(ndims(x)))
+    )
+    return 1/N * scale .* (p.p \ x)
+end
+
+plan_inv(p::AdjointPlan) = AdjointPlan(plan_inv(p.p))

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -601,10 +601,10 @@ struct AdjointPlan{T,P<:Plan} <: Plan{T}
 end
 
 """
-    p'
+    (p::Plan)'
     adjoint(p::Plan)
 
-Form the adjoint operator of an FFT plan. Returns a plan which performs the adjoint operation
+Form the adjoint operator of an FFT plan. Returns a plan that performs the adjoint operation of
 the original plan. Note that this differs from the corresponding backwards plan in the case of real
 FFTs due to the halving of one of the dimensions of the FFT output, as described in [`rfft`](@ref).
 

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -600,12 +600,15 @@ mutable struct AdjointPlan{T,P<:Plan} <: Plan{T}
 end
 
 """
+    p'
     adjoint(p::Plan)
 
-Form the adjoint operator of an FFT plan. Returns a plan `p'` which performs the adjoint operation
+Form the adjoint operator of an FFT plan. Returns a plan which performs the adjoint operation
 the original plan. Note that this differs from the corresponding backwards plan in the case of real
 FFTs due to the halving of one of the dimensions of the FFT output, as described in [`rfft`](@ref).
-Adjoint plans do not currently support `mul!`.
+
+!!! note
+    Adjoint plans do not currently support `LinearAlgebra.mul!`.
 """
 Base.adjoint(p::Plan{T}) where {T} = AdjointPlan{T, typeof(p)}(p)
 Base.adjoint(p::AdjointPlan) = p.p

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -593,9 +593,8 @@ _output_size(p::Plan, ::NoProjectionStyle) = size(p)
 _output_size(p::Plan, ::RealProjectionStyle) = rfft_output_size(size(p), fftdims(p))
 _output_size(p::Plan, s::RealInverseProjectionStyle) = brfft_output_size(size(p), s.dim, fftdims(p))
 
-mutable struct AdjointPlan{T,P<:Plan} <: Plan{T}
+struct AdjointPlan{T,P<:Plan} <: Plan{T}
     p::P
-    pinv::Plan
     AdjointPlan{T,P}(p) where {T,P} = new(p)
 end
 
@@ -653,4 +652,4 @@ function _mul(p::AdjointPlan{T}, x::AbstractArray, ::RealInverseProjectionStyle)
     return scale ./ N .* (p.p \ x)
 end
 
-plan_inv(p::AdjointPlan) = adjoint(plan_inv(p.p))
+inv(p::AdjointPlan) = adjoint(inv(p.p))

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -626,7 +626,7 @@ function _mul(p::AdjointPlan{T}, x::AbstractArray, ::NoProjectionStyle) where {T
     return (p.p \ x) / N
 end
 
-function _mul(p::AdjointPlan{T}, x::AbstractArray, ::RealProjectionStyle) where {T}
+function _mul(p::AdjointPlan{T}, x::AbstractArray, ::RealProjectionStyle) where {T<:Real}
     dims = fftdims(p.p)
     N = normalization(T, size(p.p), dims)
     halfdim = first(dims)

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -601,6 +601,14 @@ mutable struct AdjointPlan{T,P<:Plan} <: Plan{T}
     AdjointPlan{T,P}(p) where {T,P} = new(p)
 end
 
+"""
+    Base.adjoint(p::Plan)
+
+Form the adjoint operator of an FFT plan. Returns a plan `p'` which performs the adjoint operation
+the original plan. Note that this differs from the corresponding backwards plan in the case of real
+FFTs due to the halving of one of the dimensions of the FFT output, as described in [`rfft`](@ref).
+Adjoint plans do not currently support `mul!`.
+"""
 Base.adjoint(p::Plan{T}) where {T} = AdjointPlan{T, typeof(p)}(p)
 Base.adjoint(p::AdjointPlan) = p.p
 # always have AdjointPlan inside ScaledPlan.

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -592,8 +592,8 @@ function irfft_dim end
 
 output_size(p::Plan) = _output_size(p, ProjectionStyle(p))
 _output_size(p::Plan, ::NoProjectionStyle) = size(p)
-_output_size(p::Plan, ::RealProjectionStyle) = rfft_output_size(size(p), region(p))
-_output_size(p::Plan, s::RealInverseProjectionStyle) = brfft_output_size(size(p), s.dim, region(p))
+_output_size(p::Plan, ::RealProjectionStyle) = rfft_output_size(size(p), fftdims(p))
+_output_size(p::Plan, s::RealInverseProjectionStyle) = brfft_output_size(size(p), s.dim, fftdims(p))
 
 mutable struct AdjointPlan{T,P<:Plan} <: Plan{T}
     p::P
@@ -612,13 +612,13 @@ output_size(p::AdjointPlan) = size(p.p)
 Base.:*(p::AdjointPlan, x::AbstractArray) = _mul(p, x, ProjectionStyle(p.p))
 
 function _mul(p::AdjointPlan{T}, x::AbstractArray, ::NoProjectionStyle) where {T}
-    dims = region(p.p)
+    dims = fftdims(p.p)
     N = normalization(T, size(p.p), dims)
     return (p.p \ x) / N
 end
 
 function _mul(p::AdjointPlan{T}, x::AbstractArray, ::RealProjectionStyle) where {T}
-    dims = region(p.p)
+    dims = fftdims(p.p)
     N = normalization(T, size(p.p), dims)
     halfdim = first(dims)
     d = size(p.p, halfdim)
@@ -631,7 +631,7 @@ function _mul(p::AdjointPlan{T}, x::AbstractArray, ::RealProjectionStyle) where 
 end
 
 function _mul(p::AdjointPlan{T}, x::AbstractArray, ::RealInverseProjectionStyle) where {T}
-    dims = region(p.p)
+    dims = fftdims(p.p)
     N = normalization(real(T), output_size(p.p), dims)
     halfdim = first(dims)
     n = size(p.p, halfdim)

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -602,7 +602,7 @@ mutable struct AdjointPlan{T,P<:Plan} <: Plan{T}
 end
 
 """
-    Base.adjoint(p::Plan)
+    adjoint(p::Plan)
 
 Form the adjoint operator of an FFT plan. Returns a plan `p'` which performs the adjoint operation
 the original plan. Note that this differs from the corresponding backwards plan in the case of real

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -654,4 +654,6 @@ function _mul(p::AdjointPlan{T}, x::AbstractArray, ::RealInverseProjectionStyle)
     return scale ./ N .* (p.p \ x)
 end
 
+# Analogously to ScaledPlan, define both plan_inv (for no caching) and inv (caches inner plan only).
+plan_inv(p::AdjointPlan) = adjoint(plan_inv(p.p)) 
 inv(p::AdjointPlan) = adjoint(inv(p.p))

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -608,7 +608,8 @@ the original plan. Note that this differs from the corresponding backwards plan 
 FFTs due to the halving of one of the dimensions of the FFT output, as described in [`rfft`](@ref).
 
 !!! note
-    Adjoint plans do not currently support `LinearAlgebra.mul!`.
+    Adjoint plans do not currently support `LinearAlgebra.mul!`. Further, as a new addition to `AbstractFFTs`, 
+    coverage of `Base.adjoint` in downstream implementations may be limited. 
 """
 Base.adjoint(p::Plan{T}) where {T} = AdjointPlan{T, typeof(p)}(p)
 Base.adjoint(p::AdjointPlan) = p.p

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -652,6 +652,3 @@ function _mul(p::AdjointPlan{T}, x::AbstractArray, ::RealInverseProjectionStyle)
 end
 
 plan_inv(p::AdjointPlan) = adjoint(plan_inv(p.p))
-function LinearAlgebra.mul!(y::AbstractArray, p::AdjointPlan, x::AbstractArray)
-    throw(MethodError(LinearAlgebra.mul!, "mul! is not supported for adjoint plans"))
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -246,6 +246,7 @@ end
                 @test size(Pinv') == AbstractFFTs.output_size(Pinv) 
                 @test dot(x, Pinv * y) ≈ dot(Pinv' * x, y)
                 @test dot(x, Pinv \ y) ≈ dot(Pinv' \ x, y)
+                @test_throws MethodError mul!(x, P', y)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -238,7 +238,7 @@ end
             y = randn(size(x))
             for dims in unique((1, 1:N, N))
                 P = plan_fft(x, dims)
-                @test (P')' * x == P * x # test adjoint of adjoint
+                @test (P')' === P # test adjoint of adjoint
                 @test size(P') == AbstractFFTs.output_size(P) # test size of adjoint 
                 @test dot(y, P * x) ≈ dot(P' * y, x) # test validity of adjoint
                 @test dot(y, P \ x) ≈ dot(P' \ y, x)
@@ -259,13 +259,13 @@ end
                 y = randn(Complex{Float64}, size(P * x))
                 @test (P')' * x == P * x
                 @test size(P') == AbstractFFTs.output_size(P) 
-                @test dot(y_real, real.(P * x)) + dot(y_imag, imag.(P * x)) ≈ dot(P' * y, x)
-                @test dot(y_real, real.(P' \ x)) + dot(y_imag, imag.(P' \ x)) ≈ dot(P \ y, x)
+                @test dot(real.(y), real.(P * x)) + dot(imag.(y), imag.(P * x)) ≈ dot(P' * y, x)
+                @test dot(real.(y), real.(P' \ x)) + dot(imag.(y), imag.(P' \ x)) ≈ dot(P \ y, x)
                 Pinv = plan_irfft(y, size(x)[first(dims)], dims)
                 @test (Pinv')' * y == Pinv * y
                 @test size(Pinv') == AbstractFFTs.output_size(Pinv) 
-                @test dot(x, Pinv * y) ≈ dot(y_real, real.(Pinv' * x)) + dot(y_imag, imag.(Pinv' * x))
-                @test dot(x, Pinv' \ y) ≈ dot(y_real, real.(Pinv \ x)) + dot(y_imag, imag.(Pinv \ x))
+                @test dot(x, Pinv * y) ≈ dot(real.(y), real.(Pinv' * x)) + dot(imag.(y), imag.(Pinv' * x))
+                @test dot(x, Pinv' \ y) ≈ dot(real.(y), real.(Pinv \ x)) + dot(imag.(y), imag.(Pinv \ x))
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -240,12 +240,12 @@ end
                 @test (P')' * x == P * x # test adjoint of adjoint
                 @test size(P') == AbstractFFTs.output_size(P) # test size of adjoint 
                 @test dot(y, P * x) ≈ dot(P' * y, x) # test validity of adjoint
-                @test_broken dot(y, P \ x) ≈ dot(P' \ y, x)
+                @test dot(y, P \ x) ≈ dot(P' \ y, x)
                 Pinv = plan_ifft(y)
                 @test (Pinv')' * y == Pinv * y 
                 @test size(Pinv') == AbstractFFTs.output_size(Pinv) 
                 @test dot(x, Pinv * y) ≈ dot(Pinv' * x, y)
-                @test_broken dot(x, Pinv \ y) ≈ dot(Pinv' \ x, y)
+                @test dot(x, Pinv \ y) ≈ dot(Pinv' \ x, y)
             end
         end
     end
@@ -260,12 +260,12 @@ end
                 @test (P')' * x == P * x
                 @test size(P') == AbstractFFTs.output_size(P) 
                 @test dot(y_real, real.(P * x)) + dot(y_imag, imag.(P * x)) ≈ dot(P' * y, x)
-                @test_broken dot(y_real, real.(P \ x)) + dot(y_imag, imag.(P \ x)) ≈ dot(P' * y, x)
+                @test dot(y_real, real.(P' \ x)) + dot(y_imag, imag.(P' \ x)) ≈ dot(P \ y, x)
                 Pinv = plan_irfft(y, size(x)[first(dims)], dims)
                 @test (Pinv')' * y == Pinv * y
                 @test size(Pinv') == AbstractFFTs.output_size(Pinv) 
                 @test dot(x, Pinv * y) ≈ dot(y_real, real.(Pinv' * x)) + dot(y_imag, imag.(Pinv' * x))
-                @test_broken dot(x, Pinv \ y) ≈ dot(y_real, real.(Pinv' \ x)) + dot(y_imag, imag.(Pinv' \ x))
+                @test dot(x, Pinv' \ y) ≈ dot(y_real, real.(Pinv \ x)) + dot(y_imag, imag.(Pinv \ x))
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -206,7 +206,7 @@ end
             y = randn(size(x))
             for dims in unique((1, 1:N, N))
                 P = plan_fft(x, dims)
-                @test AbstractFFTs.output_size(P) == size(x)
+                @test @inferred(AbstractFFTs.output_size(P)) == size(x)
                 @test AbstractFFTs.output_size(P') == size(x)
                 Pinv = plan_ifft(x)
                 @test AbstractFFTs.output_size(Pinv) == size(x)
@@ -222,7 +222,7 @@ end
                 Px_sz = size(P * x)
                 @test AbstractFFTs.output_size(P) == Px_sz 
                 @test AbstractFFTs.output_size(P') == size(x) 
-                y = randn(Px_sz) .+ randn(Px_sz) * im
+                y = randn(Complex{Float64}, Px_sz)
                 Pinv = plan_irfft(y, size(x)[first(dims)], dims)
                 @test AbstractFFTs.output_size(Pinv) == size(Pinv * y)
                 @test AbstractFFTs.output_size(Pinv') == size(y)
@@ -256,9 +256,7 @@ end
             N = ndims(x)
             for dims in unique((1, 1:N, N))
                 P = plan_rfft(x, dims)        
-                y_real = randn(size(P * x))
-                y_imag = randn(size(P * x))
-                y = y_real .+ y_imag .* im 
+                y = randn(Complex{Float64}, size(P * x))
                 @test (P')' * x == P * x
                 @test size(P') == AbstractFFTs.output_size(P) 
                 @test dot(y_real, real.(P * x)) + dot(y_imag, imag.(P * x)) ≈ dot(P' * y, x)

--- a/test/testplans.jl
+++ b/test/testplans.jl
@@ -232,3 +232,25 @@ function Base.:*(p::InverseTestRPlan, x::AbstractArray)
 
     return y
 end
+
+# In-place plans
+# (simple wrapper of out-of-place plans that does not support inverses)
+struct InplaceTestPlan{T,P<:Plan{T}} <: Plan{T}
+    plan::P
+end
+
+Base.size(p::InplaceTestPlan) = size(p.plan)
+Base.ndims(p::InplaceTestPlan) = ndims(p.plan)
+AbstractFFTs.ProjectionStyle(p::InplaceTestPlan) = AbstractFFTs.ProjectionStyle(p.plan)
+
+function AbstractFFTs.plan_fft!(x::AbstractArray, region; kwargs...)
+    return InplaceTestPlan(plan_fft(x, region; kwargs...))
+end
+function AbstractFFTs.plan_bfft!(x::AbstractArray, region; kwargs...)
+    return InplaceTestPlan(plan_bfft(x, region; kwargs...))
+end
+
+function LinearAlgebra.mul!(y::AbstractArray, p::InplaceTestPlan, x::AbstractArray)
+    return mul!(y, p.plan, x)
+end
+Base.:*(p::InplaceTestPlan, x::AbstractArray) = copyto!(x, p.plan * x)

--- a/test/testplans.jl
+++ b/test/testplans.jl
@@ -95,11 +95,11 @@ Base.:*(p::InverseTestPlan, x::AbstractArray) = mul!(similar(x, complex(float(el
 mutable struct TestRPlan{T,N,G} <: Plan{T}
     region::G
     sz::NTuple{N,Int}
-    pinv::Plan{T}
+    pinv::Plan{Complex{T}}
     TestRPlan{T}(region::G, sz::NTuple{N,Int}) where {T,N,G} = new{T,N,G}(region, sz)
 end
 
-mutable struct InverseTestRPlan{T,N,G} <: Plan{T}
+mutable struct InverseTestRPlan{T,N,G} <: Plan{Complex{T}}
     d::Int
     region::G
     sz::NTuple{N,Int}
@@ -113,10 +113,10 @@ end
 AbstractFFTs.ProjectionStyle(::TestRPlan) = AbstractFFTs.RealProjectionStyle()
 AbstractFFTs.ProjectionStyle(p::InverseTestRPlan) = AbstractFFTs.RealInverseProjectionStyle(p.d)
 
-function AbstractFFTs.plan_rfft(x::AbstractArray{T}, region; kwargs...) where {T}
+function AbstractFFTs.plan_rfft(x::AbstractArray{T}, region; kwargs...) where {T<:Real}
     return TestRPlan{T}(region, size(x))
 end
-function AbstractFFTs.plan_brfft(x::AbstractArray{T}, d, region; kwargs...) where {T}
+function AbstractFFTs.plan_brfft(x::AbstractArray{Complex{T}}, d, region; kwargs...) where {T}
     return InverseTestRPlan{T}(d, region, size(x))
 end
 function AbstractFFTs.plan_inv(p::TestRPlan{T,N}) where {T,N}

--- a/test/testplans.jl
+++ b/test/testplans.jl
@@ -111,8 +111,7 @@ mutable struct InverseTestRPlan{T,N,G} <: Plan{T}
 end
 
 AbstractFFTs.ProjectionStyle(::TestRPlan) = AbstractFFTs.RealProjectionStyle()
-AbstractFFTs.ProjectionStyle(::InverseTestRPlan) = AbstractFFTs.RealInverseProjectionStyle()
-AbstractFFTs.irfft_dim(p::InverseTestRPlan) = p.d
+AbstractFFTs.ProjectionStyle(p::InverseTestRPlan) = AbstractFFTs.RealInverseProjectionStyle(p.d)
 
 function AbstractFFTs.plan_rfft(x::AbstractArray{T}, region; kwargs...) where {T}
     return TestRPlan{T}(region, size(x))


### PR DESCRIPTION
An `rfft` can be written as `PF` where `F` is the `n x n` Fourier transform and `P` is a projection operator that removes the redundant information due to conjuagate symmetry. Because of `P`, the adjoint of real FFTs (real inverse FFTs) require a special scaling before (after) applying the backwards transformation. As discussed in https://github.com/JuliaMath/AbstractFFTs.jl/issues/63 this motivates supporting the  `Base.adjoint` operation for plans to simplify the writing of backward rules for AD.

The following functions must be implemented by backends in order for `output_size(p::Plan)` and `AdjointPlan` to work:

- `projection_style(p::Plan)` which can either be `:none`, `:real`, or `:real_inv`.
- `irfft_dim(p::Plan)`, only for those plans with `:real_inv` projection style, which gives the original length of the halved dimension.

Using the adjoint plan, we can simplify the writing of backwards rules. I test the adjoint plans both directly and indirectly through tests of the rrule's.

NB: The interface has changed since the initial PR message. See the updated implementation docs in the PR for accurate info.