### PR TITLE
Correct inverse plan logic

### DIFF
--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -278,7 +278,7 @@ plan_ifft(x::AbstractArray, region; kws...) =
 plan_ifft!(x::AbstractArray, region; kws...) =
     ScaledPlan(plan_bfft!(x, region; kws...), normalization(x, region))
 
-plan_inv(p::ScaledPlan) = ScaledPlan(plan_inv(p.p), inv(p.scale))
+plan_inv(p::ScaledPlan) = ScaledPlan(inv(p.p), inv(p.scale))
 
 LinearAlgebra.mul!(y::AbstractArray, p::ScaledPlan, x::AbstractArray) =
     LinearAlgebra.lmul!(p.scale, LinearAlgebra.mul!(y, p.p, x))


### PR DESCRIPTION
This PR fixes some incorrect caching logic in the test plans. The reason this escaped notice is because `ScaledPlan` uses `plan_inv` rather than `inv`. That has been changed too.

**(Old Description)**

There is no need to do the caching in `plan_inv` as it should be handled by `AbstractFFTs`. The current logic leads to the following error which is now fixed.
```
julia> using AbstractFFTs
[ Info: Precompiling AbstractFFTs [621f4979-c628-5d54-868e-fcf4e3e8185c]

julia> using AbstractFFTs: Plan

julia> include("test/testplans.jl")

julia> p = plan_fft(rand(3))
TestPlan{ComplexF64, 1}(1:1, (3,), #undef)

julia> inv(inv(p).p)
ERROR: TypeError: in typeassert, expected AbstractFFTs.ScaledPlan{ComplexF64, TestPlan{ComplexF64, 1}, ComplexF64}, got a value of type TestPlan{ComplexF64, 1}
Stacktrace:
 [1] inv(p::InverseTestPlan{ComplexF64, 1})
   @ AbstractFFTs ~/repos/AbstractFFTs.jl/src/definitions.jl:237
 [2] top-level scope
   @ REPL[5]:1
```