### PR TITLE
pass init to prod in normalization

### DIFF
--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -270,15 +270,8 @@ summary(p::ScaledPlan) = string(p.scale, " * ", summary(p.p))
 *(I::UniformScaling, p::Plan) = ScaledPlan(p, I.λ)
 *(p::Plan, I::UniformScaling) = ScaledPlan(p, I.λ)
 
-# Normalization for ifft, given unscaled bfft, is 1/prod(dimensions)
-# ensure that region is a subset of eachindex(sz).
-_checkindex(szinds, region::AbstractVector) = checkindex(Bool, szinds, region)
-# this method handles the case where region is not an array, e.g. it is a Tuple
-_checkindex(szinds, region) = all(r -> checkindex(Bool, szinds, r), region)
 @inline function normalization(::Type{T}, sz, region) where T
-    @boundscheck (!isempty(region) && _checkindex(eachindex(sz), region)) ||
-        throw(BoundsError(sz, region))
-    one(T) / mapreduce(r -> Int(@inbounds sz[r])::Int, *, region; init=1)::Int
+    one(T) / mapreduce(r -> Int(sz[r])::Int, *, region; init=1)::Int
 end
 normalization(X, region) = normalization(real(eltype(X)), size(X), region)
 

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -271,7 +271,7 @@ summary(p::ScaledPlan) = string(p.scale, " * ", summary(p.p))
 *(p::Plan, I::UniformScaling) = ScaledPlan(p, I.λ)
 
 @inline function normalization(::Type{T}, sz, region) where T
-    one(T) / prod(r -> Int(sz[r])::Int, region, init=1)::Int
+    one(T) / mapreduce(r -> Int(sz[r])::Int, *, region; init=1)::Int
 end
 normalization(X, region) = normalization(real(eltype(X)), size(X), region)
 

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -278,7 +278,7 @@ _checkindex(szinds, region) = all(r -> checkindex(Bool, szinds, r), region)
 @inline function normalization(::Type{T}, sz, region) where T
     @boundscheck (!isempty(region) && _checkindex(eachindex(sz), region)) ||
         throw(BoundsError(sz, region))
-    one(T) / mapreduce(r -> Int(@inbounds sz[r])::Int, *, region; init=oneunit(eltype(sz)))::Int
+    one(T) / mapreduce(r -> Int(@inbounds sz[r])::Int, *, region; init=1)::Int
 end
 normalization(X, region) = normalization(real(eltype(X)), size(X), region)
 

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -272,7 +272,8 @@ summary(p::ScaledPlan) = string(p.scale, " * ", summary(p.p))
 
 # Normalization for ifft, given unscaled bfft, is 1/prod(dimensions)
 function normalization(::Type{T}, sz, region) where T
-    one(T) / Int(reduce(*, (sz[r] for r in region); init=1))::Int
+    @boundscheck !isempty(region) && checkindex(Bool, eachindex(sz), region)
+    one(T) / mapreduce(r -> Int(@inbounds sz[r]), *, region; init=1)
 end
 normalization(X, region) = normalization(real(eltype(X)), size(X), region)
 

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -273,7 +273,7 @@ summary(p::ScaledPlan) = string(p.scale, " * ", summary(p.p))
 # Normalization for ifft, given unscaled bfft, is 1/prod(dimensions)
 function normalization(::Type{T}, sz, region) where T
     @boundscheck !isempty(region) && checkindex(Bool, eachindex(sz), region)
-    one(T) / mapreduce(r -> Int(@inbounds sz[r]), *, region; init=1)
+    one(T) / mapreduce(r -> Int(@inbounds sz[r])::Int, *, region; init=oneunit(eltype(sz)))::Int
 end
 normalization(X, region) = normalization(real(eltype(X)), size(X), region)
 

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -271,8 +271,12 @@ summary(p::ScaledPlan) = string(p.scale, " * ", summary(p.p))
 *(p::Plan, I::UniformScaling) = ScaledPlan(p, I.λ)
 
 # Normalization for ifft, given unscaled bfft, is 1/prod(dimensions)
+# ensure that region is a subset of eachindex(sz).
+_checkindex(sz, region::AbstractVector) = checkindex(Bool, sz, region)
+# this method handles the case where region is not an array, e.g. it is a Tuple
+_checkindex(sz, region) = all(r -> checkindex(Bool, eachindex(sz), r), region)
 function normalization(::Type{T}, sz, region) where T
-    @boundscheck !isempty(region) && checkindex(Bool, eachindex(sz), region)
+    @boundscheck !isempty(region) && _checkindex(eachindex(sz), region)
     one(T) / mapreduce(r -> Int(@inbounds sz[r])::Int, *, region; init=oneunit(eltype(sz)))::Int
 end
 normalization(X, region) = normalization(real(eltype(X)), size(X), region)

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -271,7 +271,9 @@ summary(p::ScaledPlan) = string(p.scale, " * ", summary(p.p))
 *(p::Plan, I::UniformScaling) = ScaledPlan(p, I.λ)
 
 # Normalization for ifft, given unscaled bfft, is 1/prod(dimensions)
-normalization(::Type{T}, sz, region) where T = one(T) / Int(prod(sz[r] for r in region))::Int
+function normalization(::Type{T}, sz, region) where T
+    one(T) / Int(reduce(*, (sz[r] for r in region); init=1))::Int
+end
 normalization(X, region) = normalization(real(eltype(X)), size(X), region)
 
 plan_ifft(x::AbstractArray, region; kws...) =

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -271,7 +271,7 @@ summary(p::ScaledPlan) = string(p.scale, " * ", summary(p.p))
 *(p::Plan, I::UniformScaling) = ScaledPlan(p, I.λ)
 
 @inline function normalization(::Type{T}, sz, region) where T
-    one(T) / mapreduce(r -> Int(sz[r])::Int, *, region; init=1)::Int
+    one(T) / prod(r -> Int(sz[r])::Int, region, init=1)::Int
 end
 normalization(X, region) = normalization(real(eltype(X)), size(X), region)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,6 +211,9 @@ end
     # p::TestPlan)
     f9(p::Plan{T}, sz) where {T} = AbstractFFTs.normalization(real(T), sz, fftdims(p))
     @test @inferred(f9(plan_fft(zeros(10), 1), 10)) == 1/10
+
+    # normalization should be defined for 0d arrays
+    @test AbstractFFTs.normalization(zeros(), 1:0) == AbstractFFTs.normalization(zeros(1), 1:1)
 end
 
 @testset "ChainRules" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,9 +211,6 @@ end
     # p::TestPlan)
     f9(p::Plan{T}, sz) where {T} = AbstractFFTs.normalization(real(T), sz, fftdims(p))
     @test @inferred(f9(plan_fft(zeros(10), 1), 10)) == 1/10
-
-    # normalization should be defined for 0d arrays
-    @test AbstractFFTs.normalization(zeros(), 1:0) == AbstractFFTs.normalization(zeros(1), 1:1)
 end
 
 @testset "ChainRules" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,6 +211,10 @@ end
     # p::TestPlan)
     f9(p::Plan{T}, sz) where {T} = AbstractFFTs.normalization(real(T), sz, fftdims(p))
     @test @inferred(f9(plan_fft(zeros(10), 1), 10)) == 1/10
+
+    @test_throws BoundsError AbstractFFTs.normalization(Float64, (2,), 1:3)
+    @test_throws BoundsError AbstractFFTs.normalization(Float64, (2,), Int[])
+    @test_throws BoundsError AbstractFFTs.normalization(Float64, (2,), (1,3,))
 end
 
 @testset "ChainRules" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -213,7 +213,7 @@ end
     @test @inferred(f9(plan_fft(zeros(10), 1), 10)) == 1/10
 
     @test_throws BoundsError AbstractFFTs.normalization(Float64, (2,), 1:3)
-    @test_throws BoundsError AbstractFFTs.normalization(Float64, (2,), Int[])
+    # @test_throws BoundsError AbstractFFTs.normalization(Float64, (2,), Int[])
     @test_throws BoundsError AbstractFFTs.normalization(Float64, (2,), (1,3,))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -213,7 +213,6 @@ end
     @test @inferred(f9(plan_fft(zeros(10), 1), 10)) == 1/10
 
     @test_throws BoundsError AbstractFFTs.normalization(Float64, (2,), 1:3)
-    # @test_throws BoundsError AbstractFFTs.normalization(Float64, (2,), Int[])
     @test_throws BoundsError AbstractFFTs.normalization(Float64, (2,), (1,3,))
 end
 


### PR DESCRIPTION
Normalization is defined as `1/prod(dimensions)`, which should be well-defined for an empty `dimensions` (in which case the prod evaluates to `1`). This PR gets around the following error:
```julia
julia> AbstractFFTs.normalization(zeros(), 1:0)
ERROR: MethodError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer
```
and the following runtime dispatch that arises from the error:
```julia
julia> using JET

julia> @report_opt AbstractFFTs.normalization(rand(4), 1:1)
═════ 1 possible error found ═════
┌ @ /home/jishnu/Dropbox/JuliaPackages/AbstractFFTs.jl/src/definitions.jl:275 AbstractFFTs.normalization(AbstractFFTs.real(AbstractFFTs.eltype(X)), AbstractFFTs.size(X), region)
│┌ @ /home/jishnu/Dropbox/JuliaPackages/AbstractFFTs.jl/src/definitions.jl:274 AbstractFFTs.prod(Base.Generator(#91, region))
││┌ @ reduce.jl:613 Base.:(var"#prod#270")(pairs(NamedTuple()), #self#, a)
│││┌ @ reduce.jl:613 mapreduce(identity, Base.mul_prod, a)
││││┌ @ reduce.jl:302 Base.:(var"#mapreduce#263")(pairs(NamedTuple()), #self#, f, op, itr)
│││││┌ @ reduce.jl:302 mapfoldl(f, op, itr)
││││││┌ @ reduce.jl:170 Base.:(var"#mapfoldl#259")(Base._InitialValue(), #self#, f, op, itr)
│││││││┌ @ reduce.jl:170 Base.mapfoldl_impl(f, op, init, itr)
││││││││┌ @ reduce.jl:44 Base.foldl_impl(op′, nt, itr′)
│││││││││┌ @ reduce.jl:49 Base.reduce_empty_iter(op, itr)
││││││││││┌ @ reduce.jl:378 Base.reduce_empty_iter(op, itr, Base.IteratorEltype(itr))
│││││││││││┌ @ reduce.jl:379 Base.reduce_empty(op, eltype(itr))
││││││││││││┌ @ reduce.jl:356 Base.mapreduce_empty(%1, [quote], T)
│││││││││││││ runtime dispatch detected: Base.mapreduce_empty(%1::AbstractFFTs.var"#91#92"{Tuple{Int64}}, [quote]::Base.BottomRF{typeof(Base.mul_prod)}, T::Type{Int64})::Union{}
││││││││││││└─────────────────
```

After this PR,
```julia
julia> AbstractFFTs.normalization(zeros(), 1:0)
1.0

julia> @report_opt AbstractFFTs.normalization(rand(4), 1:1)
No errors detected
```