### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,24 +23,15 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
           file: lcov.info

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -10,9 +10,9 @@ jobs:
         name: Documentation
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v2
-        - uses: julia-actions/julia-buildpkg@latest
-        - uses: julia-actions/julia-docdeploy@latest
+        - uses: actions/checkout@v3
+        - uses: julia-actions/julia-buildpkg@v1
+        - uses: julia-actions/julia-docdeploy@v1
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -20,14 +20,14 @@ jobs:
           - {user: JuliaMath, repo: FFTW.jl}
           - {user: JuliaApproximation, repo: FastTransforms.jl}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
           arch: x64
-      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-buildpkg@v1
       - name: Clone Downstream
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
           path: downstream


### PR DESCRIPTION
This PR updates the Github actions, switches to julia-actions/cache and adds proper versioning to all actions (with dependabot we don't have to worry about outdated actions but rather about breaking updates IMO).

Closes #90. Closes #92. Closes #91.