### PR TITLE
For conversion of scale vector in adjoint

### DIFF
--- a/ext/AbstractFFTsChainRulesCoreExt.jl
+++ b/ext/AbstractFFTsChainRulesCoreExt.jl
@@ -37,7 +37,9 @@ function ChainRulesCore.rrule(::typeof(rfft), x::AbstractArray{<:Real}, dims)
 
     project_x = ChainRulesCore.ProjectTo(x)
     function rfft_pullback(ȳ)
-        x̄ = project_x(brfft(ChainRulesCore.unthunk(ȳ) ./ scale, d, dims))
+        ybar = ChainRulesCore.unthunk(ȳ)
+        _scale = convert(typeof(ybar),scale)
+        x̄ = project_x(brfft(ybar ./ _scale, d, dims))
         return ChainRulesCore.NoTangent(), x̄, ChainRulesCore.NoTangent()
     end
     return y, rfft_pullback

--- a/ext/AbstractFFTsChainRulesCoreExt.jl
+++ b/ext/AbstractFFTsChainRulesCoreExt.jl
@@ -81,7 +81,9 @@ function ChainRulesCore.rrule(::typeof(irfft), x::AbstractArray, d::Int, dims)
 
     project_x = ChainRulesCore.ProjectTo(x)
     function irfft_pullback(ȳ)
-        x̄ = project_x(scale .* rfft(real.(ChainRulesCore.unthunk(ȳ)), dims))
+        ybar = ChainRulesCore.unthunk(ȳ)
+        _scale = convert(typeof(ybar),scale)
+        x̄ = project_x(_scale .* rfft(real.(ybar), dims))
         return ChainRulesCore.NoTangent(), x̄, ChainRulesCore.NoTangent(), ChainRulesCore.NoTangent()
     end
     return y, irfft_pullback


### PR DESCRIPTION
It always defines an `Array` which can fail on the GPU. This forces it to be the right type. One could also use `adapt` here, but since the element type promotion would have to occur anyways in the subsequent broadcast it seems you might as well convert all at once.