### PR TITLE
Rename ProjectionStyle -> AdjointStyle, _mul -> AdjointMul, and improve docs

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,5 +1,7 @@
 # Public Interface
 
+## FFT and FFT planning functions
+
 ```@docs
 AbstractFFTs.fft
 AbstractFFTs.fft!
@@ -20,15 +22,26 @@ AbstractFFTs.plan_rfft
 AbstractFFTs.plan_brfft
 AbstractFFTs.plan_irfft
 AbstractFFTs.fftdims
-Base.adjoint
-AbstractFFTs.FFTAdjointStyle
-AbstractFFTs.RFFTAdjointStyle
-AbstractFFTs.IRFFTAdjointStyle
-AbstractFFTs.UnitaryAdjointStyle
 AbstractFFTs.fftshift
 AbstractFFTs.fftshift!
 AbstractFFTs.ifftshift
 AbstractFFTs.ifftshift!
 AbstractFFTs.fftfreq
 AbstractFFTs.rfftfreq
+Base.size
+```
+
+## Adjoint functionality
+
+The following API is supported by plans that support adjoint functionality.
+It is also relevant to implementers of FFT plans that wish to support adjoints.
+```@docs
+Base.adjoint
+AbstractFFTs.AdjointStyle
+AbstractFFTs.output_size
+AbstractFFTs.adjoint_mul
+AbstractFFTs.FFTAdjointStyle
+AbstractFFTs.RFFTAdjointStyle
+AbstractFFTs.IRFFTAdjointStyle
+AbstractFFTs.UnitaryAdjointStyle
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -21,6 +21,10 @@ AbstractFFTs.plan_brfft
 AbstractFFTs.plan_irfft
 AbstractFFTs.fftdims
 Base.adjoint
+AbstractFFTs.FFTAdjointStyle
+AbstractFFTs.RFFTAdjointStyle
+AbstractFFTs.IRFFTAdjointStyle
+AbstractFFTs.UnitaryAdjointStyle
 AbstractFFTs.fftshift
 AbstractFFTs.fftshift!
 AbstractFFTs.ifftshift

--- a/docs/src/implementations.md
+++ b/docs/src/implementations.md
@@ -34,8 +34,7 @@ To define a new FFT implementation in your own module, you should
 
 * To support adjoints in a new plan, define the trait [`AbstractFFTs.AdjointStyle`](@ref).
   `AbstractFFTs` implements the following adjoint styles: [`AbstractFFTs.FFTAdjointStyle`](@ref), [`AbstractFFTs.RFFTAdjointStyle`](@ref), [`AbstractFFTs.IRFFTAdjointStyle`](@ref), and [`AbstractFFTs.UnitaryAdjointStyle`](@ref).
-  To define a new adjoint style of type `AS <: AbstractFFTs.AdjointStyle`, define the methods
-  [`AbstractFFTs.adjoint_mul`](@ref) and [`AbstractFFTs.output_size`](@ref).
+  To define a new adjoint style, define the methods [`AbstractFFTs.adjoint_mul`](@ref) and [`AbstractFFTs.output_size`](@ref).
 
 The normalization convention for your FFT should be that it computes ``y_k = \sum_j x_j \exp(-2\pi i j k/n)`` for a transform of
 length ``n``, and the "backwards" (unnormalized inverse) transform computes the same thing but with ``\exp(+2\pi i jk/n)``.

--- a/docs/src/implementations.md
+++ b/docs/src/implementations.md
@@ -32,10 +32,11 @@ To define a new FFT implementation in your own module, you should
 
 * You can also define similar methods of `plan_rfft` and `plan_brfft` for real-input FFTs.
 
-* To enable automatic computation of adjoint plans via [`Base.adjoint`](@ref) (used in rules for reverse-mode differentiation), define the trait `AbstractFFTs.ProjectionStyle(::MyPlan)`, which can return:
-    * `AbstractFFTs.NoProjectionStyle()`,
-    * `AbstractFFTs.RealProjectionStyle()`, for plans that halve one of the output's dimensions analogously to [`rfft`](@ref),
-    * `AbstractFFTs.RealInverseProjectionStyle(d::Int)`, for plans that expect an input with a halved dimension analogously to [`irfft`](@ref), where `d` is the original length of the dimension.
+* We offer an experimental `AdjointStyle` trait to enable automatic computation of adjoint plans via [`Base.adjoint`](@ref). 
+  To support adjoints in a new plan, define the trait `AbstractFFTs.AdjointStyle(::MyPlan)`. This should return a subtype of `AS <: AbstractFFTs.AdjointStyle` supporting `AbstractFFTs.adjoint_mul(::Plan, ::AbstractArray, ::AS)` and 
+  `AbstractFFTs._output_size(::Plan, ::AS)`. 
+
+  `AbstractFFTs` pre-implements the following adjoint styles: [`AbstractFFTs.FFTAdjointStyle`](@ref), [`AbstractFFTs.RFFTAdjointStyle`](@ref), [`AbstractFFTs.IRFFTAdjointStyle`](@ref), and [`AbstractFFTs.UnitaryAdjointStyle`](@ref).
 
 The normalization convention for your FFT should be that it computes ``y_k = \sum_j x_j \exp(-2\pi i j k/n)`` for a transform of
 length ``n``, and the "backwards" (unnormalized inverse) transform computes the same thing but with ``\exp(+2\pi i jk/n)``.

--- a/docs/src/implementations.md
+++ b/docs/src/implementations.md
@@ -18,7 +18,8 @@ To define a new FFT implementation in your own module, you should
   inverse plan.
 
 * Define a new method `AbstractFFTs.plan_fft(x, region; kws...)` that returns a `MyPlan` for at least some types of
-  `x` and some set of dimensions `region`.   The `region` (or a copy thereof) should be accessible via `fftdims(p::MyPlan)` (which defaults to `p.region`).
+  `x` and some set of dimensions `region`.   The `region` (or a copy thereof) should be accessible via `fftdims(p::MyPlan)`
+   (which defaults to `p.region`), and the input size `size(x)` should be accessible via `size(p::MyPlan)`.
 
 * Define a method of `LinearAlgebra.mul!(y, p::MyPlan, x)` that computes the transform `p` of `x` and stores the result in `y`.
 

--- a/docs/src/implementations.md
+++ b/docs/src/implementations.md
@@ -32,11 +32,10 @@ To define a new FFT implementation in your own module, you should
 
 * You can also define similar methods of `plan_rfft` and `plan_brfft` for real-input FFTs.
 
-* We offer an experimental `AdjointStyle` trait to enable automatic computation of adjoint plans via [`Base.adjoint`](@ref). 
-  To support adjoints in a new plan, define the trait `AbstractFFTs.AdjointStyle(::MyPlan)`. This should return a subtype of `AS <: AbstractFFTs.AdjointStyle` supporting `AbstractFFTs.adjoint_mul(::Plan, ::AbstractArray, ::AS)` and 
-  `AbstractFFTs._output_size(::Plan, ::AS)`. 
-
-  `AbstractFFTs` pre-implements the following adjoint styles: [`AbstractFFTs.FFTAdjointStyle`](@ref), [`AbstractFFTs.RFFTAdjointStyle`](@ref), [`AbstractFFTs.IRFFTAdjointStyle`](@ref), and [`AbstractFFTs.UnitaryAdjointStyle`](@ref).
+* To support adjoints in a new plan, define the trait [`AbstractFFTs.AdjointStyle`](@ref).
+  `AbstractFFTs` implements the following adjoint styles: [`AbstractFFTs.FFTAdjointStyle`](@ref), [`AbstractFFTs.RFFTAdjointStyle`](@ref), [`AbstractFFTs.IRFFTAdjointStyle`](@ref), and [`AbstractFFTs.UnitaryAdjointStyle`](@ref).
+  To define a new adjoint style of type `AS <: AbstractFFTs.AdjointStyle`, define the methods
+  [`AbstractFFTs.adjoint_mul`](@ref) and [`AbstractFFTs.output_size`](@ref).
 
 The normalization convention for your FFT should be that it computes ``y_k = \sum_j x_j \exp(-2\pi i j k/n)`` for a transform of
 length ``n``, and the "backwards" (unnormalized inverse) transform computes the same thing but with ``\exp(+2\pi i jk/n)``.

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -610,8 +610,8 @@ Adjoint style for real to complex discrete Fourier transforms that halve one of
 the output's dimensions and normalize the output analogously to [`rfft`](@ref).
     
 Since the Fourier transform is unitary up to a scaling, the adjoint applies the transform's 
-inverse, but with additional logic to handle the fact that the output is projected 
-to exploit its conjugate symmetry (see [`rfft`](@ref)). 
+inverse, but with appropriate scaling and additional logic to handle the fact that the
+output is projected to exploit its conjugate symmetry (see [`rfft`](@ref)).
 """
 struct RFFTAdjointStyle <: AdjointStyle end 
 
@@ -623,8 +623,8 @@ with a halved dimension and normalize the output analogously to [`irfft`](@ref),
 where `d` is the original length of the dimension.
     
 Since the Fourier transform is unitary up to a scaling, the adjoint applies the transform's 
-inverse, but with additional logic to handle the fact that the input is projected 
-to exploit its conjugate symmetry (see [`irfft`](@ref)). 
+inverse, but with appropriate scaling and additional logic to handle the fact that the
+input is projected to exploit its conjugate symmetry (see [`irfft`](@ref)). 
 """
 struct IRFFTAdjointStyle <: AdjointStyle
     dim::Int

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -10,9 +10,12 @@ abstract type Plan{T} end
 
 eltype(::Type{<:Plan{T}}) where {T} = T
 
-# size(p) should return the size of the input array for p
-size(p::Plan, d) = size(p)[d]
-output_size(p::Plan, d) = output_size(p)[d]
+"""
+    size(p::Plan, [dim])
+
+Return the size of the input of a plan `p`, optionally at a specified dimenion `dim`.
+"""
+size(p::Plan, dim) = size(p)[dim]
 ndims(p::Plan) = length(size(p))
 length(p::Plan) = prod(size(p))::Int
 
@@ -638,13 +641,14 @@ Adjoint style for unitary transforms, whose adjoint equals their inverse.
 struct UnitaryAdjointStyle <: AdjointStyle end
 
 """
-    output_size(p::Plan)
+    output_size(p::Plan, [dim])
 
-Return the size of the output of a plan `p`.
+Return the size of the output of a plan `p`, optionally at a specified dimension `dim`.
 
 Implementations of a new adjoint style `AS <: AbstractFFTs.AdjointStyle` should define `output_size(::Plan, ::AS)`.
 """
 output_size(p::Plan) = output_size(p, AdjointStyle(p))
+output_size(p::Plan, dim) = output_size(p)[dim]
 output_size(p::Plan, ::FFTAdjointStyle) = size(p)
 output_size(p::Plan, ::RFFTAdjointStyle) = rfft_output_size(size(p), fftdims(p))
 output_size(p::Plan, s::IRFFTAdjointStyle) = brfft_output_size(size(p), s.dim, fftdims(p))
@@ -670,11 +674,6 @@ Base.adjoint(p::AdjointPlan) = p.p
 # always have AdjointPlan inside ScaledPlan.
 Base.adjoint(p::ScaledPlan) = ScaledPlan(p.p', p.scale)
 
-"""
-    size(p::Plan)
-
-Return the size of the input of a plan `p`.
-"""
 size(p::AdjointPlan) = output_size(p.p)
 output_size(p::AdjointPlan) = size(p.p)
 

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -588,8 +588,9 @@ abstract type AdjointStyle end
 """
     FFTAdjointStyle()
 
-Projection style for complex to complex discrete Fourier transforms. 
-    
+Projection style for complex to complex discrete Fourier transforms that normalize 
+the output analogously to [`fft`](@ref).
+
 Since the Fourier transform is unitary up to a scaling, the adjoint simply applies 
 the transform's inverse with an appropriate scaling.
 """
@@ -598,8 +599,8 @@ struct FFTAdjointStyle <: AdjointStyle end
 """
     RFFTAdjointStyle()
 
-Projection style for real to complex discrete Fourier transforms, for plans that 
-halve one of the output's dimensions analogously to [`rfft`](@ref).
+Projection style for real to complex discrete Fourier transforms that halve
+one of the output's dimensions and normalize the output analogously to [`rfft`](@ref).
     
 Since the Fourier transform is unitary up to a scaling, the adjoint applies the transform's 
 inverse, but with additional logic to handle the fact that the output is projected 
@@ -610,9 +611,9 @@ struct RFFTAdjointStyle <: AdjointStyle end
 """
     IRFFTAdjointStyle(d::Dim)
 
-Projection style for complex to real discrete Fourier transforms, for plans that 
-expect an input with a halved dimension analogously to [`irfft`](@ref), where `d` 
-is the original length of the dimension.
+Projection style for complex to real discrete Fourier transforms that expect
+an input with a halved dimension and normalize the output analogously to [`irfft`](@ref), 
+where `d` is the original length of the dimension.
     
 Since the Fourier transform is unitary up to a scaling, the adjoint applies the transform's 
 inverse, but with additional logic to handle the fact that the input is projected 

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -607,7 +607,7 @@ struct FFTAdjointStyle <: AdjointStyle end
     RFFTAdjointStyle()
 
 Adjoint style for real to complex discrete Fourier transforms that halve one of
-the output's dimensions and normalize the output, analogously to [`rfft`](@ref).
+the output's dimensions and normalize the output analogously to [`rfft`](@ref).
     
 Since the Fourier transform is unitary up to a scaling, the adjoint applies the transform's 
 inverse, but with additional logic to handle the fact that the output is projected 
@@ -619,7 +619,7 @@ struct RFFTAdjointStyle <: AdjointStyle end
     IRFFTAdjointStyle(d::Dim)
 
 Adjoint style for complex to real discrete Fourier transforms that expect an input
-with a halved dimension and normalize the output, analogously to [`irfft`](@ref),
+with a halved dimension and normalize the output analogously to [`irfft`](@ref),
 where `d` is the original length of the dimension.
     
 Since the Fourier transform is unitary up to a scaling, the adjoint applies the transform's 

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -583,12 +583,30 @@ plan_brfft
 
 ##############################################################################
 
-struct NoProjectionStyle end
-struct RealProjectionStyle end 
-struct RealInverseProjectionStyle 
+abstract type ProjectionStyle end
+
+"""
+    NoProjectionStyle()
+
+Projection style for complex to complex discrete Fourier transform
+"""
+struct NoProjectionStyle <: ProjectionStyle end
+
+"""
+    RealProjectionStyle()
+
+Projection style for complex to real discrete Fourier transform
+"""
+struct RealProjectionStyle <: ProjectionStyle end 
+
+"""
+    RealInverseProjectionStyle()
+
+Projection style for inverse of complex to real discrete Fourier transform
+"""
+struct RealInverseProjectionStyle <: ProjectionStyle
     dim::Int
 end
-const ProjectionStyle = Union{NoProjectionStyle, RealProjectionStyle, RealInverseProjectionStyle}
 
 output_size(p::Plan) = _output_size(p, ProjectionStyle(p))
 _output_size(p::Plan, ::NoProjectionStyle) = size(p)

--- a/test/testplans.jl
+++ b/test/testplans.jl
@@ -21,8 +21,8 @@ Base.ndims(::TestPlan{T,N}) where {T,N} = N
 Base.size(p::InverseTestPlan) = p.sz
 Base.ndims(::InverseTestPlan{T,N}) where {T,N} = N
 
-AbstractFFTs.ProjectionStyle(::TestPlan) = AbstractFFTs.NoProjectionStyle()
-AbstractFFTs.ProjectionStyle(::InverseTestPlan) = AbstractFFTs.NoProjectionStyle()
+AbstractFFTs.AdjointStyle(::TestPlan) = AbstractFFTs.FFTAdjointStyle()
+AbstractFFTs.AdjointStyle(::InverseTestPlan) = AbstractFFTs.FFTAdjointStyle()
 
 function AbstractFFTs.plan_fft(x::AbstractArray{T}, region; kwargs...) where {T}
     return TestPlan{T}(region, size(x))
@@ -110,8 +110,8 @@ mutable struct InverseTestRPlan{T,N,G} <: Plan{Complex{T}}
     end
 end
 
-AbstractFFTs.ProjectionStyle(::TestRPlan) = AbstractFFTs.RealProjectionStyle()
-AbstractFFTs.ProjectionStyle(p::InverseTestRPlan) = AbstractFFTs.RealInverseProjectionStyle(p.d)
+AbstractFFTs.AdjointStyle(::TestRPlan) = AbstractFFTs.RFFTAdjointStyle()
+AbstractFFTs.AdjointStyle(p::InverseTestRPlan) = AbstractFFTs.IRFFTAdjointStyle(p.d)
 
 function AbstractFFTs.plan_rfft(x::AbstractArray{T}, region; kwargs...) where {T<:Real}
     return TestRPlan{T}(region, size(x))
@@ -241,7 +241,7 @@ end
 
 Base.size(p::InplaceTestPlan) = size(p.plan)
 Base.ndims(p::InplaceTestPlan) = ndims(p.plan)
-AbstractFFTs.ProjectionStyle(p::InplaceTestPlan) = AbstractFFTs.ProjectionStyle(p.plan)
+AbstractFFTs.AdjointStyle(p::InplaceTestPlan) = AbstractFFTs.AdjointStyle(p.plan)
 
 function AbstractFFTs.plan_fft!(x::AbstractArray, region; kwargs...)
     return InplaceTestPlan(plan_fft(x, region; kwargs...))


### PR DESCRIPTION
This PR makes the projection styles subtypes of an abstract type. This is so that new projection styles can be added in downstream packages. In FFTW.jl, we are defining projection styles for DCT and FFTW.R2R transforms in https://github.com/JuliaMath/FFTW.jl/pull/249.

@gaurav-arya can you add a few lines of documentation for the different ProjectionStyles? For example,

- [x] which `fft` function does each projection style correspond to?
- [x] what is the normalization scheme involved

~I fear that the names are slightly confusing. Specifically, `NoProjectionStyle` made it seem like it would be applicable to unitary transforms. But it looks like `NoProjectionStyle` is applicable to `fft/bfft`.~

