### PR TITLE
Eagerly invert plan on formation of AdjointPlan: correct eltype and remove output_size

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -38,7 +38,6 @@ It is also relevant to implementers of FFT plans that wish to support adjoints.
 ```@docs
 Base.adjoint
 AbstractFFTs.AdjointStyle
-AbstractFFTs.output_size
 AbstractFFTs.adjoint_mul
 AbstractFFTs.FFTAdjointStyle
 AbstractFFTs.RFFTAdjointStyle

--- a/docs/src/implementations.md
+++ b/docs/src/implementations.md
@@ -35,7 +35,7 @@ To define a new FFT implementation in your own module, you should
 
 * To support adjoints in a new plan, define the trait [`AbstractFFTs.AdjointStyle`](@ref).
   `AbstractFFTs` implements the following adjoint styles: [`AbstractFFTs.FFTAdjointStyle`](@ref), [`AbstractFFTs.RFFTAdjointStyle`](@ref), [`AbstractFFTs.IRFFTAdjointStyle`](@ref), and [`AbstractFFTs.UnitaryAdjointStyle`](@ref).
-  To define a new adjoint style, define the methods [`AbstractFFTs.adjoint_mul`](@ref) and [`AbstractFFTs.output_size`](@ref).
+  To define a new adjoint style, define the method [`AbstractFFTs.adjoint_mul`](@ref).
 
 The normalization convention for your FFT should be that it computes ``y_k = \sum_j x_j \exp(-2\pi i j k/n)`` for a transform of
 length ``n``, and the "backwards" (unnormalized inverse) transform computes the same thing but with ``\exp(+2\pi i jk/n)``.

--- a/ext/AbstractFFTsTestExt.jl
+++ b/ext/AbstractFFTsTestExt.jl
@@ -73,9 +73,9 @@ function TestUtils.test_plan_adjoint(P::AbstractFFTs.Plan, x::AbstractArray; rea
     _copy = copy_input ? copy : identity
     y = rand(eltype(P * _copy(x)), size(P * _copy(x)))
     # test basic properties
-    @test_skip eltype(P') === typeof(y) # (AbstractFFTs.jl#110)
+    @test eltype(P') === eltype(y)
     @test (P')' === P # test adjoint of adjoint
-    @test size(P') == AbstractFFTs.output_size(P) # test size of adjoint 
+    @test size(P') == size(y) # test size of adjoint
     # test correctness of adjoint and its inverse via the dot test
     if !real_plan
         @test dot(y, P * _copy(x)) ≈ dot(P' * _copy(y), x)

--- a/ext/AbstractFFTsTestExt.jl
+++ b/ext/AbstractFFTsTestExt.jl
@@ -54,6 +54,7 @@ const TEST_CASES = (
 
 function TestUtils.test_plan(P::AbstractFFTs.Plan, x::AbstractArray, x_transformed::AbstractArray; inplace_plan=false, copy_input=false)
     _copy = copy_input ? copy : identity
+    @test size(P) == size(x)
     if !inplace_plan
         @test P * _copy(x) ≈ x_transformed
         @test P \ (P * _copy(x)) ≈ x

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -683,12 +683,11 @@ function adjoint_mul(p::Plan{T}, x::AbstractArray, ::FFTAdjointStyle) where {T}
     pinv = inv(p)
     # Optimization: when pinv is a ScaledPlan, check if we can avoid a loop over x.
     # Even if not, ensure that we do only one pass by combining the normalization with the plan.
-    scaled_pinv = if pinv isa ScaledPlan && isapprox(pinv.scale, N)
-        pinv.p
+    if pinv isa ScaledPlan && isapprox(pinv.scale, N)
+        return pinv.p * x
     else
-        (1/N) * pinv
+        return (1/N * pinv) * x
     end
-    return scaled_pinv * x
 end
 
 function adjoint_mul(p::Plan{T}, x::AbstractArray, ::RFFTAdjointStyle) where {T<:Real}

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -683,7 +683,7 @@ function adjoint_mul(p::Plan{T}, x::AbstractArray, ::FFTAdjointStyle) where {T}
     pinv = inv(p)
     # Optimization: when pinv is a ScaledPlan, check if we can avoid a loop over x.
     # Even if not, ensure that we do only one pass by combining the normalization with the plan.
-    if pinv isa ScaledPlan && isapprox(pinv.scale, N)
+    if pinv isa ScaledPlan && pinv.scale == N
         return pinv.p * x
     else
         return (1/N * pinv) * x

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -699,11 +699,12 @@ function adjoint_mul(p::Plan{T}, x::AbstractArray, ::RFFTAdjointStyle) where {T<
     n = size(pinv, halfdim)
     # Optimization: when pinv is a ScaledPlan, fuse the scaling into our map to ensure we do not loop over x twice.
     scale = pinv isa ScaledPlan ? pinv.scale / 2N : 1 / 2N
+    twoscale = 2 * scale 
     unscaled_pinv = pinv isa ScaledPlan ? pinv.p : pinv 
     y = map(x, CartesianIndices(x)) do xj, j
         i = j[halfdim]
         yj = if i == 1 || (i == n && 2 * (i - 1) == d)
-            xj * scale * 2
+            xj * twoscale
         else
             xj * scale
         end
@@ -721,6 +722,7 @@ function adjoint_mul(p::Plan{T}, x::AbstractArray, ::IRFFTAdjointStyle) where {T
     d = size(pinv, halfdim)
     # Optimization: when pinv is a ScaledPlan, fuse the scaling into our map to ensure we do not loop over x twice.
     scale = pinv isa ScaledPlan ? pinv.scale / N : 1 / N
+    twoscale = 2 * scale 
     unscaled_pinv = pinv isa ScaledPlan ? pinv.p : pinv 
     y = unscaled_pinv * x
     z = map(y, CartesianIndices(y)) do yj, j
@@ -728,7 +730,7 @@ function adjoint_mul(p::Plan{T}, x::AbstractArray, ::IRFFTAdjointStyle) where {T
         zj = if i == 1 || (i == n && 2 * (i - 1) == d)
             yj * scale
         else
-            yj * scale * 2
+            yj * twoscale
         end
         return zj
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,41 +118,6 @@ end
     @test @inferred(f9(plan_fft(zeros(10), 1), 10)) == 1/10
 end
 
-@testset "output size" begin
-    @testset "complex fft output size" begin
-        for x_shape in ((3,), (3, 4), (3, 4, 5))
-            N = length(x_shape)
-            real_x = randn(x_shape)
-            complex_x = randn(ComplexF64, x_shape)
-            for x in (real_x, complex_x)
-                for dims in unique((1, 1:N, N))
-                    P = plan_fft(x, dims)
-                    @test @inferred(AbstractFFTs.output_size(P)) == size(x)
-                    @test AbstractFFTs.output_size(P') == size(x)
-                    Pinv = plan_ifft(x)
-                    @test AbstractFFTs.output_size(Pinv) == size(x)
-                    @test AbstractFFTs.output_size(Pinv') == size(x)
-                end
-            end
-        end
-    end
-    @testset "real fft output size" begin
-        for x in (randn(3), randn(4), randn(3, 4), randn(3, 4, 5)) # test odd and even lengths
-            N = ndims(x)
-            for dims in unique((1, 1:N, N))
-                P = plan_rfft(x, dims)        
-                Px_sz = size(P * x)
-                @test AbstractFFTs.output_size(P) == Px_sz 
-                @test AbstractFFTs.output_size(P') == size(x) 
-                y = randn(ComplexF64, Px_sz)
-                Pinv = plan_irfft(y, size(x)[first(dims)], dims)
-                @test AbstractFFTs.output_size(Pinv) == size(Pinv * y)
-                @test AbstractFFTs.output_size(Pinv') == size(y)
-            end
-        end
-    end
-end
-
 # Test that dims defaults to 1:ndims for fft-like functions
 @testset "Default dims" begin
     for x in (randn(3), randn(3, 4), randn(3, 4, 5))


### PR DESCRIPTION
This PR resolves #110. After some thinking I realized that the right way to do this should be to actually call `inv(p)` in the formation of the adjoint plan. This makes `adjoint(p)` work the same way as `inv(p)`, in that caching occurs in the plan formation rather than plan application.

As a consequence, I realized that  `output_size` should not actually be job of an adjoint style. TPlan implementers are actually already required to manually figure out output size for their plan when implementing `size(plan_inv(p))`, and hence it didn't actually make sense to have the adjoint style trait provide this. If we want to make to make the output size available for free without forming the inverse plan, that's a separate line of work (that could also simplify the lives of the original plan implementation) But it shouldn't actually be the job of adjoint traits -- the goal of adjoint traits is to make adjoints easy given that all inverse functionality is implemented, and indeed inverses already give the output size for free.

Note that this PR is technically breaking for implementers of *new* adjoint styles (by removing 1 required function). but does not affect users of existing adjoint styles.

Edit: this PR also includes the fusion optimization suggested in https://github.com/JuliaMath/AbstractFFTs.jl/pull/113#issuecomment-1688865004.