### PR TITLE
Remove arrays of scaling factors

### DIFF
--- a/ext/AbstractFFTsTestExt.jl
+++ b/ext/AbstractFFTsTestExt.jl
@@ -60,6 +60,7 @@ function TestUtils.test_plan(P::AbstractFFTs.Plan, x::AbstractArray, x_transform
         _x_out = similar(P * _copy(x))
         @test mul!(_x_out, P, _copy(x)) ≈ x_transformed
         @test _x_out ≈ x_transformed
+        @test P * view(_copy(x), axes(x)...) ≈ x_transformed # test view input
     else
         _x = copy(x)
         @test P * _copy(_x) ≈ x_transformed
@@ -85,6 +86,7 @@ function TestUtils.test_plan_adjoint(P::AbstractFFTs.Plan, x::AbstractArray; rea
         @test _component_dot(y, P * _copy(x)) ≈ _component_dot(P' * _copy(y), x)
         @test _component_dot(x, P \ _copy(y)) ≈ _component_dot(P' \ _copy(x), y) 
     end
+    @test P' * view(_copy(y), axes(y)...) ≈ P' * _copy(y) # test view input (AbstractFFTs.jl#112)
     @test_throws MethodError mul!(x, P', y)
 end
 

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -724,9 +724,9 @@ function adjoint_mul(p::Plan{T}, x::AbstractArray, ::IRFFTAdjointStyle) where {T
     z = map(y, CartesianIndices(y)) do yj, j
         i = j[halfdim]
         zj = if i == 1 || (i == n && 2 * (i - 1) == d)
-            zj / N
+            yj / N
         else
-            2 * zj / N
+            2 * yj / N
         end
         return zj
     end


### PR DESCRIPTION
Alternative to https://github.com/JuliaMath/AbstractFFTs.jl/pull/114 that avoids the computation of the array of scaling factors completely.

Tested locally with regular arrays and static arrays. Using `broadcast` instead of `map` (potentially including `d` etc. as broadcasted arguments) would return `SizedArray`s instead of `StaticArray`s for `SArray` inputs, hence I went with `map` instead.

Has to be tested with Zygote and CUDA as well (for the latter it might be useful to set up GPU tests with buildkite and for the former downstream tests with Zygote, limited to FFTs, would be useful).

Edit: Tests of Zygote#master pass locally with this PR.