### PR TITLE
Fixes to test suite to support CUDA arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.5.0"
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [weakdeps]

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "1.5.0"
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [weakdeps]

--- a/ext/AbstractFFTsTestExt.jl
+++ b/ext/AbstractFFTsTestExt.jl
@@ -62,7 +62,9 @@ function TestUtils.test_plan(P::AbstractFFTs.Plan, x::AbstractArray, x_transform
         _x_out = similar(P * _copy(x))
         @test mul!(_x_out, P, _copy(x)) ≈ x_transformed
         @test _x_out ≈ x_transformed
-        @test P * view(_copy(x), axes(x)...) ≈ x_transformed skip=!test_wrappers # test view input
+        if test_wrappers
+            @test P * view(_copy(x), axes(x)...) ≈ x_transformed # test view input
+        end
     else
         _x = copy(x)
         @test P * _copy(_x) ≈ x_transformed
@@ -89,7 +91,9 @@ function TestUtils.test_plan_adjoint(P::AbstractFFTs.Plan, x::AbstractArray;
         @test _component_dot(y, P * _copy(x)) ≈ _component_dot(P' * _copy(y), x)
         @test _component_dot(x, P \ _copy(y)) ≈ _component_dot(P' \ _copy(x), y) 
     end
-    @test P' * view(_copy(y), axes(y)...) ≈ P' * _copy(y) skip=!test_wrappers # test view input (AbstractFFTs.jl#112)
+    if test_wrappers
+        @test P' * view(_copy(y), axes(y)...) ≈ P' * _copy(y) # test view input (AbstractFFTs.jl#112)
+    end
     @test_throws MethodError mul!(x, P', y)
 end
 

--- a/ext/AbstractFFTsTestExt.jl
+++ b/ext/AbstractFFTsTestExt.jl
@@ -62,9 +62,7 @@ function TestUtils.test_plan(P::AbstractFFTs.Plan, x::AbstractArray, x_transform
         _x_out = similar(P * _copy(x))
         @test mul!(_x_out, P, _copy(x)) ≈ x_transformed
         @test _x_out ≈ x_transformed
-        if test_wrappers
-            @test P * view(_copy(x), axes(x)...) ≈ x_transformed # test view input
-        end
+        @test P * view(_copy(x), axes(x)...) ≈ x_transformed skip=!test_wrappers # test view input
     else
         _x = copy(x)
         @test P * _copy(_x) ≈ x_transformed
@@ -91,9 +89,7 @@ function TestUtils.test_plan_adjoint(P::AbstractFFTs.Plan, x::AbstractArray;
         @test _component_dot(y, P * _copy(x)) ≈ _component_dot(P' * _copy(y), x)
         @test _component_dot(x, P \ _copy(y)) ≈ _component_dot(P' \ _copy(x), y) 
     end
-    if test_wrappers
-        @test P' * view(_copy(y), axes(y)...) ≈ P' * _copy(y) # test view input (AbstractFFTs.jl#112)
-    end
+    @test P' * view(_copy(y), axes(y)...) ≈ P' * _copy(y) skip=!test_wrappers # test view input (AbstractFFTs.jl#112)
     @test_throws MethodError mul!(x, P', y)
 end
 

--- a/ext/AbstractFFTsTestExt.jl
+++ b/ext/AbstractFFTsTestExt.jl
@@ -6,7 +6,6 @@ using AbstractFFTs
 using AbstractFFTs: TestUtils
 using AbstractFFTs.LinearAlgebra
 using Test
-import Random
 
 # Ground truth x_fft computed using FFTW library
 const TEST_CASES = (
@@ -78,7 +77,7 @@ end
 function TestUtils.test_plan_adjoint(P::AbstractFFTs.Plan, x::AbstractArray;
                                      real_plan=false, copy_input=false, test_wrappers=true)
     _copy = copy_input ? copy : identity
-    y = Random.rand!(P * _copy(x))
+    y = map(a -> rand(typeof(a)), P * _copy(x)) # generically construct rand array
     # test basic properties
     @test eltype(P') === eltype(y)
     @test (P')' === P # test adjoint of adjoint

--- a/src/TestUtils.jl
+++ b/src/TestUtils.jl
@@ -3,7 +3,7 @@ module TestUtils
 import ..AbstractFFTs
 
 """
-    TestUtils.test_complex_ffts(ArrayType=Array; test_inplace=true, test_adjoint=true) 
+    TestUtils.test_complex_ffts(ArrayType=Array; test_inplace=true, test_adjoint=true, test_wrappers=true) 
 
 Run tests to verify correctness of FFT, BFFT, and IFFT functionality using a particular backend plan implementation. 
 The backend implementation is assumed to be loaded prior to calling this function.
@@ -15,11 +15,12 @@ The backend implementation is assumed to be loaded prior to calling this functio
   `convert(ArrayType, ...)`.
 - `test_inplace=true`: whether to test in-place plans. 
 - `test_adjoint=true`: whether to test [plan adjoints](api.md#Base.adjoint). 
+- `test_wrappers=true`: whether to test any wrapper array inputs such as views. 
 """
 function test_complex_ffts end
 
 """
-    TestUtils.test_real_ffts(ArrayType=Array; test_adjoint=true, copy_input=false)
+    TestUtils.test_real_ffts(ArrayType=Array; test_adjoint=true, copy_input=false, test_wrappers=true)
 
 Run tests to verify correctness of RFFT, BRFFT, and IRFFT functionality using a particular backend plan implementation. 
 The backend implementation is assumed to be loaded prior to calling this function.
@@ -32,18 +33,21 @@ The backend implementation is assumed to be loaded prior to calling this functio
 - `test_adjoint=true`: whether to test [plan adjoints](api.md#Base.adjoint). 
 - `copy_input=false`: whether to copy the input before applying the plan in tests, to accomodate for 
   [input-mutating behaviour of real FFTW plans](https://github.com/JuliaMath/AbstractFFTs.jl/issues/101).
+- `test_wrappers=true`: whether to test any wrapper array inputs such as views. 
 """
 function test_real_ffts end
 
     # Always copy input before application due to FFTW real plans possibly mutating input (AbstractFFTs.jl#101)
 """
     TestUtils.test_plan(P::Plan, x::AbstractArray, x_transformed::AbstractArray;
-                        inplace_plan=false, copy_input=false)
+                        inplace_plan=false, copy_input=false, test_wrappers=true)
 
 Test basic properties of a plan `P` given an input array `x` and expected output `x_transformed`.
 
 Because [real FFTW plans may mutate their input in some cases](https://github.com/JuliaMath/AbstractFFTs.jl/issues/101), 
 we allow specifying `copy_input=true` to allow for this behaviour in tests by copying the input before applying the plan.
+We also allow specifying `test_wrappers=false` to skip testing wrapper array inputs such as views, which may cause ambiguity
+issues for some array types currently.
 """
 function test_plan end
 
@@ -57,6 +61,8 @@ Real-to-complex and complex-to-real plans require a slightly modified dot test, 
 The plan is assumed out-of-place, as adjoints are not yet supported for in-place plans.
 Because [real FFTW plans may mutate their input in some cases](https://github.com/JuliaMath/AbstractFFTs.jl/issues/101), 
 we allow specifying `copy_input=true` to allow for this behaviour in tests by copying the input before applying the plan.
+We also allow specifying `test_wrappers=false` to skip testing wrapper array inputs such as views, which may cause ambiguity
+issues for some array types currently.
 """
 function test_plan_adjoint end
 


### PR DESCRIPTION
Implemented changes:

- A more generic construction of the random array in `test_plan_adjoint` 
- An option to disable testing wrapper types (in our case, views), since we do not support them correctly when it comes to avoiding ambiguities with `*` (see #119. I don't expect it to be solved in the immediate future, which is why I prefer to work around it for now).
- Tests correctness of `fftdims` as an iterable rather than its specific form, in accordance with the function contract.