### PR TITLE
Fix bug with TestUtils error hint handler

### DIFF
--- a/src/TestUtils.jl
+++ b/src/TestUtils.jl
@@ -1,5 +1,7 @@
 module TestUtils
 
+import ..AbstractFFTs
+
 """
     TestUtils.test_complex_ffts(ArrayType=Array; test_inplace=true, test_adjoint=true) 
 


### PR DESCRIPTION
Previously, the use of `AbstractFFTs` within the `get_extension` call threw an error within the error hint handler.