### PR TITLE
Add codecov token

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,4 +34,6 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }} # required
+          fail_ci_if_error: true
           file: lcov.info


### PR DESCRIPTION
This PR fixes codecov integration (see the discussion in #128). @DilumAluthge added an orgwide codecov token for JuliaMath (AFAIK) and hence this should work without any additional changes or new Github secrets in AbstractFFTs.

Closes #128.