### PR TITLE
ci: run tests with `macos-15-x64` and `macos-latest-aarch64`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,21 +32,14 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
-          - macos-13 # Intel
+          - macos-latest # Apple silicon
           - windows-latest
-        arch:
-          - x64
+        exclude:
+          - os: macos-latest
+            version: '1.0'
         include:
-          # macos-latest -> Apple Silicon (Need julia >= v1.8)
-          - os: macos-latest
-            arch: 'aarch64'
-            version: 'lts'
-          - os: macos-latest
-            arch: 'aarch64'
-            version: '1'
-          - os: macos-latest
-            arch: 'aarch64'
-            version: 'nightly'
+          - os: macos-13 # Intel
+            version: '1.0'
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,7 +45,6 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,6 +36,17 @@ jobs:
           - windows-latest
         arch:
           - x64
+        include:
+          # macos-latest -> Apple Silicon
+          - os: macos-latest
+            julia-arch: 'aarch64'
+            julia-version: '1.0'
+          - os: macos-latest
+            julia-arch: 'aarch64'
+            julia-version: '1'
+          - os: macos-latest
+            julia-arch: 'aarch64'
+            julia-version: 'nightly'
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,10 +37,10 @@ jobs:
         arch:
           - x64
         include:
-          # macos-latest -> Apple Silicon
+          # macos-latest -> Apple Silicon (Need julia >= v1.8)
           - os: macos-latest
             arch: 'aarch64'
-            version: '1.0'
+            version: 'lts'
           - os: macos-latest
             arch: 'aarch64'
             version: '1'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
-          - macOS-latest
+          - macos-13 # Intel
           - windows-latest
         arch:
           - x64

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,14 +39,14 @@ jobs:
         include:
           # macos-latest -> Apple Silicon
           - os: macos-latest
-            julia-arch: 'aarch64'
-            julia-version: '1.0'
+            arch: 'aarch64'
+            version: '1.0'
           - os: macos-latest
-            julia-arch: 'aarch64'
-            julia-version: '1'
+            arch: 'aarch64'
+            version: '1'
           - os: macos-latest
-            julia-arch: 'aarch64'
-            julia-version: 'nightly'
+            arch: 'aarch64'
+            version: 'nightly'
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,4 +61,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # required
           fail_ci_if_error: true
-          file: lcov.info
+          files: lcov.info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,14 +32,14 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
-          - macos-latest # Apple silicon
+          - macos-15-intel
           - windows-latest
         exclude:
           - os: macos-latest
             version: '1.0'
         include:
-          - os: macos-13 # Intel
-            version: '1.0'
+          - os: macos-latest # Apple Silicon
+            version: '1'
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A general framework for fast Fourier transforms (FFTs) in Julia.
 
-[![GHA](https://github.com/JuliaMath/AbstractFFTs.jl/workflows/CI/badge.svg)](https://github.com/JuliaMath/AbstractFFTs.jl/actions?query=workflow%3ACI+branch%3Amaster)
+[![CI](https://github.com/JuliaMath/AbstractFFTs.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/JuliaMath/AbstractFFTs.jl/actions/workflows/CI.yml?query=branch%3Amaster)
 [![Codecov](https://codecov.io/github/JuliaMath/AbstractFFTs.jl/graph/badge.svg?token=ZJrE86Hpz7)](https://codecov.io/github/JuliaMath/AbstractFFTs.jl)
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
@@ -18,4 +18,3 @@ This allows multiple FFT packages to co-exist with the same underlying `fft(x)` 
 ## Developer information
 
 To define a new FFT implementation in your own module, see [defining a new implementation](https://juliamath.github.io/AbstractFFTs.jl/stable/implementations/#Defining-a-new-implementation).
-

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A general framework for fast Fourier transforms (FFTs) in Julia.
 
 [![GHA](https://github.com/JuliaMath/AbstractFFTs.jl/workflows/CI/badge.svg)](https://github.com/JuliaMath/AbstractFFTs.jl/actions?query=workflow%3ACI+branch%3Amaster)
-[![Codecov](http://codecov.io/github/JuliaMath/AbstractFFTs.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaMath/AbstractFFTs.jl?branch=master)
+[![Codecov](https://codecov.io/github/JuliaMath/AbstractFFTs.jl/graph/badge.svg?token=ZJrE86Hpz7)](https://codecov.io/github/JuliaMath/AbstractFFTs.jl)
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
 Documentation:


### PR DESCRIPTION
- Run tests with `macos-latest` (Apple Silicon) by default
- Skip `macos-latest * v1.0`, Apple Silicon need julia >= v1.8
- Run tests with `macos-13 * x64 * v1.0`
- Fix deprecated arg `file -> files` in `codecov/codecov-action@v5`
- Update codecov badge
