### PR TITLE
Change FastTransforms.jl to GenericFFT.jl in downstream tests

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -28,7 +28,7 @@ jobs:
         os: [ubuntu-latest]
         package:
           - {user: JuliaMath, repo: FFTW.jl}
-          - {user: JuliaApproximation, repo: FastTransforms.jl}
+          - {user: JuliaApproximation, repo: GenericFFT.jl}
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
The relevant support for generic FFTs was moved out of FastTransforms.jl and into its own package a long time ago.

